### PR TITLE
Removed unnecessary dependence on logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "dataclasses",
     "ipykernel",
     "jupyter",
-    "logging",
     "matplotlib",
     "numpy",
     "ovito",


### PR DESCRIPTION
I got this error when trying to install on python 3.12. After consulting with an AI, I determined that the logging package is no longer needed, since its functionality is included in the python standard library since Python 3.x. Removing the dependency does not require any change in the code.

```
Collecting logging (from PySlice==0.1.0)
  Downloading logging-0.4.9.6.tar.gz (96 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
   python setup.py egg_info did not run successfully.
   exit code: 1
  > [24 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 14, in <module>
        File "/opt/miniconda3/envs/pytorch/lib/python3.12/site-packages/setuptools/__init__.py", line 22, in <module>
          import _distutils_hack.override  # noqa: F401
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/opt/miniconda3/envs/pytorch/lib/python3.12/site-packages/_distutils_hack/override.py", line 1, in <module>
          __import__('_distutils_hack').do_override()
        File "/opt/miniconda3/envs/pytorch/lib/python3.12/site-packages/_distutils_hack/__init__.py", line 89, in do_override
          ensure_local_distutils()
        File "/opt/miniconda3/envs/pytorch/lib/python3.12/site-packages/_distutils_hack/__init__.py", line 75, in ensure_local_distutils
          core = importlib.import_module('distutils.core')
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/opt/miniconda3/envs/pytorch/lib/python3.12/importlib/__init__.py", line 90, in import_module
          return _bootstrap._gcd_import(name[level:], package, level)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/opt/miniconda3/envs/pytorch/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 16, in <module>
          from .cmd import Command
        File "/opt/miniconda3/envs/pytorch/lib/python3.12/site-packages/setuptools/_distutils/cmd.py", line 9, in <module>
          import logging
        File "/tmp/pip-install-0xw6sn29/logging_790f2f1885c54131b8ead0e2411f327c/logging/__init__.py", line 618
          raise NotImplementedError, 'emit must be implemented '\
                                   ^
      SyntaxError: invalid syntax
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
```