### PR TITLE
Claude Code review and fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,18 +25,21 @@ md = ["orb-models>=0.6.0; python_version < '3.13'"]
 [project.urls]
 Homepage = "https://github.com/h-walk/PySlice"
 
-[tool.setuptools.package-data]
-mypkg = ["data/*.txt", "data/*.json"]
-
-[tool.hatch.build]
-include = [
-    "src/pyslice/data/*.txt",
-    "src/pyslice/data/*.json",
-]
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pyslice"]
+
+# The sdist needs its own file list: without it hatchling inherited the old
+# global data-only include and shipped zero Python source, so any sdist-based
+# install (PyPI, `python -m build`, `uv build`) produced an empty package.
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src/pyslice",
+    "/README.md",
+    "/LICENSE",
+    "/INSTALL.md",
+    "/pyproject.toml",
+]

--- a/src/pyslice/backend.py
+++ b/src/pyslice/backend.py
@@ -1,6 +1,7 @@
 # backend.py - Backend abstraction layer for NumPy/PyTorch support
 from __future__ import annotations
 
+import hashlib
 import os
 import logging
 from abc import ABC, abstractmethod
@@ -10,6 +11,27 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
+
+
+def source_files_version(paths, length: int = 8) -> str:
+    """Short content hash of the given source files.
+
+    Used to derive cache-version tags automatically: when any listed module's
+    source changes, the hash changes, so caches keyed on it are not reused with
+    stale physics. It errs toward over-invalidation (any edit, even a comment,
+    changes the hash) because recomputing is the safe failure mode. Missing or
+    unreadable files contribute a fixed marker instead of raising, so this never
+    breaks importing the package (e.g. from a zipapp).
+    """
+    h = hashlib.sha256()
+    for path in sorted(str(p) for p in paths):
+        h.update(path.encode())
+        try:
+            with open(path, "rb") as f:
+                h.update(f.read())
+        except OSError:
+            h.update(b"\x00<unreadable>")
+    return h.hexdigest()[:length]
 
 # ---------------------------------------------------------------------------
 # Optional torch import

--- a/src/pyslice/io/loader.py
+++ b/src/pyslice/io/loader.py
@@ -15,6 +15,22 @@ from ..multislice.potentials import get_z_from_element
 
 logger = logging.getLogger(__name__)
 
+
+def _ovito_cell_to_row_convention(matrix):
+    """Convert an OVITO cell matrix to PySlice's row convention plus origin.
+
+    OVITO stores the three lattice vectors in the COLUMNS of a 3x4 matrix, with
+    the cell origin in the 4th column. PySlice (and the ASE path) store lattice
+    vectors as ROWS, so the 3x3 vector block is transposed. Returns
+    ``(box_matrix_rows, origin)``.
+    """
+    cell_np = np.asarray(matrix, dtype=np.float32)
+    h_matrix = cell_np[:3, :3].T
+    origin = (cell_np[:3, 3].copy() if cell_np.shape[1] > 3
+              else np.zeros(3, dtype=np.float32))
+    return h_matrix, origin
+
+
 class Loader:
     """Load a file or ASE object into the internal ``Trajectory`` representation.
 
@@ -308,7 +324,11 @@ except RuntimeError as exc:
 validate_frame_data(frame0_data, 0)
 
 n_atoms = len(frame0_data.particles.positions)
-h_matrix = np.array(frame0_data.cell.matrix, dtype=np.float32)[:3, :3]
+# OVITO stores lattice vectors in the columns of a 3x4 matrix (4th column is
+# the origin); transpose to PySlice's row convention and keep the origin.
+cell_np = np.array(frame0_data.cell.matrix, dtype=np.float32)
+h_matrix = cell_np[:3, :3].T
+cell_origin = cell_np[:3, 3].copy() if cell_np.shape[1] > 3 else np.zeros(3, dtype=np.float32)
 has_velocities = (
     hasattr(frame0_data.particles, "velocities")
     and frame0_data.particles.velocities is not None
@@ -334,6 +354,9 @@ for i in range(n_frames):
                 velocities[i] = np.array(frame_data.particles.velocities, dtype=np.float32)
     except Exception as exc:
         print(f"Failed to load frame {i}: {exc}", file=sys.stderr)
+
+if np.any(cell_origin != 0):
+    positions -= cell_origin
 
 pt = getattr(frame0_data.particles, "particle_types", None)
 type_ids = []
@@ -437,9 +460,12 @@ np.savez(
 
         self._validate_frame_data(frame0_data, 0)
 
-        # Extract basic info
+        # Extract basic info. OVITO stores the lattice vectors in the COLUMNS of
+        # a 3x4 matrix (the 4th column is the cell origin). Transpose to the
+        # row-vector convention used everywhere else in PySlice (and by the ASE
+        # path), and keep the origin so positions can be referenced to it.
         n_atoms = len(frame0_data.particles.positions)
-        h_matrix = np.array(frame0_data.cell.matrix, dtype=np.float32)[:3, :3]
+        h_matrix, cell_origin = _ovito_cell_to_row_convention(frame0_data.cell.matrix)
 
         has_velocities = (hasattr(frame0_data.particles, 'velocities') and
                          frame0_data.particles.velocities is not None)
@@ -466,6 +492,11 @@ np.savez(
             except Exception as e:
                 logger.error(f"Failed to load frame {i}: {e}")
                 continue
+
+        # Reference positions to the cell origin so they live in [0, L), matching
+        # the multislice grid (which starts at 0).
+        if np.any(cell_origin != 0):
+            positions -= cell_origin
 
         # Get per-atom type IDs and the element names OVITO embeds for each type.
         pt = getattr(frame0_data.particles, 'particle_types', None)

--- a/src/pyslice/io/loader.py
+++ b/src/pyslice/io/loader.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -31,6 +32,40 @@ def _ovito_cell_to_row_convention(matrix):
     return h_matrix, origin
 
 
+def _parse_index(index):
+    """Parse a frame selector into an ``int`` or ``slice``.
+
+    Accepts an int, a ``slice``, or an ASE-like string:
+    ``":"`` (all), ``":3"`` (first 3), ``"-3:"`` (last 3), ``"::2"`` (every
+    other), ``"3:5"`` (Python slice, 3 and 4), ``"3-5"`` (inclusive range, 3 to
+    5), or a bare integer like ``"1"`` / ``"-1"``.
+    """
+    if isinstance(index, (int, np.integer)):
+        return int(index)
+    if isinstance(index, slice):
+        return index
+    if not isinstance(index, str):
+        raise ValueError(
+            f"index must be an int, slice or str; got {type(index).__name__}")
+    s = index.strip()
+    if ":" in s:
+        parts = s.split(":")
+        if len(parts) > 3:
+            raise ValueError(f"invalid slice index {index!r}")
+        parts = (parts + ["", "", ""])[:3]
+        to_int = lambda x: int(x) if x.strip() else None
+        return slice(to_int(parts[0]), to_int(parts[1]), to_int(parts[2]))
+    m = re.fullmatch(r"(\d+)\s*-\s*(\d+)", s)
+    if m:  # inclusive dash-range, e.g. "3-5" -> frames 3, 4, 5
+        return slice(int(m.group(1)), int(m.group(2)) + 1)
+    try:
+        return int(s)
+    except ValueError:
+        raise ValueError(
+            f"Unrecognised index {index!r}. Use ':', '3-5', ':3', '-3:', "
+            "'::2', an int, or a slice.")
+
+
 class Loader:
     """Load a file or ASE object into the internal ``Trajectory`` representation.
 
@@ -47,7 +82,8 @@ class Loader:
                  atomic_numbers: Optional[Dict[int, int]] = None,
                  element_names: Optional[Dict[int, str]] = None,
                  ovitokwargs: Optional[Dict[str,str]] = None,
-                 atoms = None ):
+                 atoms = None,
+                 index: Union[int, str, slice] = ":" ):
         """
         Initialize a trajectory loader.
 
@@ -61,6 +97,10 @@ class Loader:
             element_names: Deprecated; use atom_mapping instead.
             ovitokwargs: Additional keyword arguments forwarded to OVITO import.
             atoms: ASE Atoms object or trajectory. If provided, file loading is skipped.
+            index: Which frames/images to load, ASE-like. Default ":" loads all.
+                Accepts an int, a slice, or a string: ":", ":3", "-3:", "::2",
+                "3:5" (Python slice) or "3-5" (inclusive range). A step (e.g.
+                "::2") rescales the trajectory timestep accordingly.
         """
         if timestep is not None and timestep <= 0:
             raise ValueError("timestep must be positive if specified.")
@@ -80,6 +120,10 @@ class Loader:
 
         # Process atom mapping
         self.atomic_numbers = self._process_atom_mapping(atom_mapping)
+
+        # Frame selection (applied after loading; default ":" = all frames)
+        self.index = index
+        self._index = _parse_index(index)
 
     def _process_atom_mapping(self, mapping: Optional[Dict[int, Union[int, str]]]) -> Optional[Dict[int, int]]:
         """Convert atom mapping to atomic numbers."""
@@ -211,26 +255,41 @@ class Loader:
         # If atoms object provided, convert directly
         if self.atoms is not None:
             logger.info("Converting ASE Atoms object to Trajectory")
-            return self.ase2Trajectory(self.atoms)
+            return self._apply_frame_index(self.ase2Trajectory(self.atoms))
 
-        # Try cache first
+        # Try cache first (the cache always holds every frame; `index` is applied
+        # as a view below, so different selections share one cache).
         trajectory = self._load_from_cache()
-        if trajectory is not None:
+        if trajectory is None:
+            # Load via OVITO or ASE
+            # CIF files use ASE because OVITO's CIF parser is limited (e.g., fails on multi-block CIF files)
+            if self.filepath.suffix in [".cif"]:
+                logger.info(f"Loading {self.filepath.name} via ASE")
+                trajectory = self._load_via_ase()
+            else:
+                logger.info(f"Loading {self.filepath.name} via OVITO")
+                trajectory = self._load_via_ovito()
+            self._save_to_cache(trajectory)
+
+        return self._apply_frame_index(trajectory)
+
+    def _apply_frame_index(self, trajectory: Trajectory) -> Trajectory:
+        """Select frames per ``self._index`` (int or slice); ``:`` is a no-op."""
+        n = trajectory.n_frames
+        frame_ids = np.atleast_1d(np.arange(n)[self._index])
+        if frame_ids.size == 0:
+            raise ValueError(
+                f"index {self.index!r} selected no frames from a {n}-frame source")
+        if frame_ids.size == n and np.array_equal(frame_ids, np.arange(n)):
             return trajectory
-
-        # Load via OVITO or ASE
-        # CIF files use ASE because OVITO's CIF parser is limited (e.g., fails on multi-block CIF files)
-        if self.filepath.suffix in [".cif"]:
-            logger.info(f"Loading {self.filepath.name} via ASE")
-            trajectory = self._load_via_ase()
-        else:
-            logger.info(f"Loading {self.filepath.name} via OVITO")
-            trajectory = self._load_via_ovito()
-
-        # Save to cache
-        self._save_to_cache(trajectory)
-
-        return trajectory
+        step = self._index.step if isinstance(self._index, slice) and self._index.step else 1
+        return Trajectory(
+            atom_types=trajectory.atom_types,
+            positions=trajectory.positions[frame_ids],
+            velocities=trajectory.velocities[frame_ids],
+            box_matrix=trajectory.box_matrix,
+            timestep=trajectory.timestep * abs(step),
+        )
 
     def _validate_frame_data(self, frame_data, frame_num: int = 0) -> None:
         """Validate OVITO frame data."""
@@ -525,7 +584,11 @@ np.savez(
 
     def _load_via_ase(self) -> Trajectory:
         from ase.io import read as aseread
-        atoms = aseread(str(self.filepath))
+        # index=":" reads EVERY image: ase.io.read defaults to index=-1 (last
+        # frame only), which silently dropped all but the last block of a
+        # multi-frame/multi-block CIF. Frame selection is applied afterwards via
+        # self._index so the cache still stores the full trajectory.
+        atoms = aseread(str(self.filepath), index=":")
         return self.ase2Trajectory(atoms)
 
     def ase2Trajectory(self, atoms):

--- a/src/pyslice/io/loader.py
+++ b/src/pyslice/io/loader.py
@@ -85,25 +85,50 @@ class Loader:
 
         return result
 
-    def _apply_atomic_mapping(self, atom_types: np.ndarray) -> np.ndarray:
-        """Apply atomic number mapping to atom types."""
-        if self.atomic_numbers is None:
-            return atom_types
+    def _resolve_ovito_types(self, atom_type_ids: np.ndarray,
+                             type_names: Optional[Dict[int, str]]) -> np.ndarray:
+        """Resolve OVITO particle-type IDs to element identities.
 
-        mapped_types = atom_types.copy()
-        unique_types = np.unique(atom_types)
-        unmapped_types = []
+        Element identity comes from an explicit ``atom_mapping`` when provided,
+        otherwise from the element names embedded in the file (OVITO's
+        ``ParticleType.name``).  LAMMPS-style integer type IDs are NEVER used as
+        atomic numbers; if neither source yields a valid element for every type
+        present, loading aborts and asks for an explicit mapping.
+        """
+        atom_type_ids = np.asarray(atom_type_ids)
+        used = [int(t) for t in np.unique(atom_type_ids)]
 
-        for atom_type in unique_types:
-            if atom_type in self.atomic_numbers:
-                mapped_types[atom_types == atom_type] = self.atomic_numbers[atom_type]
-            else:
-                unmapped_types.append(atom_type)
+        # 1) Explicit mapping wins, but it must be exact (cover every type).
+        if self.atomic_numbers is not None:
+            missing = [t for t in used if t not in self.atomic_numbers]
+            if missing:
+                raise ValueError(
+                    f"atom_mapping is missing entries for particle type(s) "
+                    f"{missing}. Provide an exact mapping for every type, e.g. "
+                    f"atom_mapping={{{used[0]}: 'Si', ...}}."
+                )
+            return np.array([self.atomic_numbers[int(t)] for t in atom_type_ids],
+                            dtype=np.int32)
 
-        if unmapped_types:
-            logger.warning(f"No mapping provided for atom types {unmapped_types}.")
-
-        return mapped_types
+        # 2) Otherwise use the element names embedded in the file.
+        type_names = type_names or {}
+        symbols, unresolved = {}, []
+        for t in used:
+            name = str(type_names.get(t, "") or "").strip()
+            try:
+                get_z_from_element(name)  # validates it is a real element symbol
+                symbols[t] = name
+            except ValueError:
+                unresolved.append((t, name))
+        if unresolved:
+            raise ValueError(
+                "Could not identify elements from the file for particle "
+                f"type(s) {[t for t, _ in unresolved]} (embedded names: "
+                f"{[n for _, n in unresolved]!r}). LAMMPS type IDs are not "
+                "element identities. Supply an exact atom_mapping, e.g. "
+                f"atom_mapping={{{used[0]}: 'Si'}}."
+            )
+        return np.array([symbols[int(t)] for t in atom_type_ids])
 
     def _get_cache_files(self) -> Dict[str, Path]:
         """Get paths for cache files.
@@ -310,14 +335,16 @@ for i in range(n_frames):
     except Exception as exc:
         print(f"Failed to load frame {i}: {exc}", file=sys.stderr)
 
-if (
-    hasattr(frame0_data.particles, "particle_types")
-    and frame0_data.particles.particle_types is not None
-    and len(frame0_data.particles.particle_types) == n_atoms
-):
-    atom_types = np.array(frame0_data.particles.particle_types, dtype=np.int32)
+pt = getattr(frame0_data.particles, "particle_types", None)
+type_ids = []
+type_names = []
+if pt is not None and len(pt) == n_atoms:
+    atom_types = np.array(pt, dtype=np.int32)
+    for t in (getattr(pt, "types", None) or []):
+        type_ids.append(int(t.id))
+        type_names.append(str(t.name or ""))
 else:
-    print("No particle type data found. Setting all types to 1.", file=sys.stderr)
+    print("No particle type data found. Treating all atoms as one type.", file=sys.stderr)
     atom_types = np.ones(n_atoms, dtype=np.int32)
 
 np.savez(
@@ -325,6 +352,8 @@ np.savez(
     positions=positions,
     velocities=velocities,
     atom_types=atom_types,
+    type_ids=np.array(type_ids, dtype=np.int32),
+    type_names=np.array(type_names, dtype="<U16"),
     box_matrix=h_matrix,
 )
 '''
@@ -345,7 +374,9 @@ np.savez(
             with np.load(output_path) as data:
                 positions = data["positions"]
                 velocities = data["velocities"]
-                atom_types = self._apply_atomic_mapping(data["atom_types"])
+                type_names = {int(i): str(n) for i, n
+                              in zip(data["type_ids"], data["type_names"])}
+                atom_types = self._resolve_ovito_types(data["atom_types"], type_names)
                 box_matrix = data["box_matrix"]
 
         logger.info(f"Loaded {positions.shape[0]} frames with {positions.shape[1]} atoms")
@@ -436,17 +467,20 @@ np.savez(
                 logger.error(f"Failed to load frame {i}: {e}")
                 continue
 
-        # Get atom types
-        if (hasattr(frame0_data.particles, 'particle_types') and
-            frame0_data.particles.particle_types is not None and
-            len(frame0_data.particles.particle_types) == n_atoms):
-            atom_types = np.array(frame0_data.particles.particle_types, dtype=np.int32)
+        # Get per-atom type IDs and the element names OVITO embeds for each type.
+        pt = getattr(frame0_data.particles, 'particle_types', None)
+        if pt is not None and len(pt) == n_atoms:
+            atom_type_ids = np.array(pt, dtype=np.int32)
+            type_names = {int(t.id): (t.name or "").strip()
+                          for t in (getattr(pt, 'types', None) or [])}
         else:
-            logger.warning("No particle type data found. Setting all types to 1.")
-            atom_types = np.ones(n_atoms, dtype=np.int32)
+            logger.warning("No particle type data found. Treating all atoms as one type.")
+            atom_type_ids = np.ones(n_atoms, dtype=np.int32)
+            type_names = {}
 
-        # Apply atomic mapping
-        atom_types = self._apply_atomic_mapping(atom_types)
+        # Resolve to element identities (explicit mapping or embedded names;
+        # never the raw LAMMPS type IDs).
+        atom_types = self._resolve_ovito_types(atom_type_ids, type_names)
 
         logger.info(f"Loaded {n_frames} frames with {n_atoms} atoms")
 

--- a/src/pyslice/io/loader.py
+++ b/src/pyslice/io/loader.py
@@ -1,6 +1,7 @@
 """Load structures and trajectories into PySlice ``Trajectory`` objects."""
 import numpy as np
 from pathlib import Path
+import hashlib
 import json
 import logging
 import os
@@ -13,6 +14,7 @@ from typing import Optional, Dict, Union
 
 from ..multislice.trajectory import Trajectory
 from ..multislice.potentials import get_z_from_element
+from ..backend import source_files_version
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +75,10 @@ class Loader:
     inputs handled through ASE.  Loaded arrays are cached next to the source
     file as ``*.npy`` files so repeated loads avoid parser overhead.
     """
+
+    # The cache stores parser output, so parser changes must invalidate old
+    # arrays just as surely as changes to the source file or import options do.
+    _CACHE_VERSION = "v1-" + source_files_version([__file__])
 
     def __init__(self,
                  filename: Optional[str] = None,
@@ -202,7 +208,33 @@ class Loader:
             'positions': cache_base.with_suffix(cache_base.suffix + '.positions.npy'),
             'velocities': cache_base.with_suffix(cache_base.suffix + '.velocities.npy'),
             'atom_types': cache_base.with_suffix(cache_base.suffix + '.atom_types.npy'),
-            'box_matrix': cache_base.with_suffix(cache_base.suffix + '.box_matrix.npy')
+            'box_matrix': cache_base.with_suffix(cache_base.suffix + '.box_matrix.npy'),
+            'metadata': cache_base.with_suffix(cache_base.suffix + '.cache.json'),
+        }
+
+    def _cache_identity(self) -> dict:
+        """Return all inputs that can change the cached parser output."""
+        digest = hashlib.sha256()
+        with open(self.filepath, "rb") as source:
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(chunk)
+
+        mapping = None
+        if self.atomic_numbers is not None:
+            mapping = sorted(
+                [int(atom_type), int(atomic_number)]
+                for atom_type, atomic_number in self.atomic_numbers.items()
+            )
+        # Keep this as canonical JSON text. OVITO keyword values are normally
+        # JSON-compatible; default=repr still gives uncommon custom values a
+        # deterministic cache partition instead of disabling caching entirely.
+        ovito_options = json.dumps(
+            self.ovitokwargs, sort_keys=True, separators=(",", ":"), default=repr)
+        return {
+            "cache_version": self._CACHE_VERSION,
+            "source_sha256": digest.hexdigest(),
+            "atom_mapping": mapping,
+            "ovito_options": ovito_options,
         }
 
     def _load_from_cache(self) -> Optional[Trajectory]:
@@ -213,6 +245,11 @@ class Loader:
             return None
 
         try:
+            with open(cache_files['metadata']) as f:
+                if json.load(f) != self._cache_identity():
+                    logger.info("Ignoring stale cache for %s", self.filepath.name)
+                    return None
+
             logger.info(f"Loading from cache for {self.filepath.name}")
 
             pos = np.load(cache_files['positions'])
@@ -249,6 +286,13 @@ class Loader:
         np.save(cache_files['velocities'], trajectory.velocities)
         np.save(cache_files['atom_types'], trajectory.atom_types)
         np.save(cache_files['box_matrix'], trajectory.box_matrix)
+        # Written last: the metadata file is the completion marker for the
+        # four-array cache, as well as its provenance record.
+        metadata_tmp = cache_files['metadata'].with_suffix(
+            cache_files['metadata'].suffix + '.tmp')
+        with open(metadata_tmp, 'w') as f:
+            json.dump(self._cache_identity(), f, sort_keys=True)
+        metadata_tmp.replace(cache_files['metadata'])
 
     def load(self) -> Trajectory:
         """Load structure/trajectory from file or ASE Atoms object and return as Trajectory."""

--- a/src/pyslice/md/molecular_dynamics.py
+++ b/src/pyslice/md/molecular_dynamics.py
@@ -274,6 +274,21 @@ class MDCalculator:
 
         return atoms
 
+    @staticmethod
+    def _npt_barostat_params(pressure_bar: float, bulk_modulus_GPa: float):
+        """Return (externalstress, pfactor) for ase.md.npt.NPT, in ASE units.
+
+        externalstress is the target pressure converted from bar to eV/A^3;
+        pfactor = ptime^2 * B with ptime = 75 fs (ASE's suggested value) and B
+        the bulk modulus. Passing the bar value directly (as before) applied
+        ~1.6e5 bar, and pfactor = 75*fs**2 both dropped the square on ptime and
+        omitted B, so the barostat mass was ~10^5x too small.
+        """
+        externalstress = pressure_bar * units.bar
+        ptime = 75 * units.fs
+        pfactor = ptime ** 2 * (bulk_modulus_GPa * units.GPa)
+        return externalstress, pfactor
+
     def setup(
         self,
         atoms: Atoms,
@@ -281,6 +296,7 @@ class MDCalculator:
         timestep: float = 1.0,
         ensemble: str = 'nvt',
         pressure: float = 1.01325,
+        bulk_modulus: float = 100.0,
         friction: float = 0.02,
         production_ensemble: Optional[str] = None,
         production_friction: Optional[float] = None,
@@ -306,6 +322,9 @@ class MDCalculator:
             timestep: MD timestep (fs)
             ensemble: 'nvt', 'npt', or 'nve' (for equilibration)
             pressure: Target pressure for NPT (bar)
+            bulk_modulus: Approximate bulk modulus of the material (GPa), used to
+                          size the NPT barostat (pfactor = ptime^2 * B). Adjust
+                          per material; the default (100 GPa) is a metal-ish value.
             friction: Friction coefficient for Langevin thermostat during equilibration (fs^-1)
             production_ensemble: Ensemble for production run (default: same as equilibration)
                                  Use 'nve' for noise-free dynamics suitable for TACAW analysis
@@ -331,6 +350,7 @@ class MDCalculator:
         self.timestep = timestep
         self.ensemble = ensemble
         self.pressure = pressure
+        self.bulk_modulus = bulk_modulus
         self.friction = friction
         self.production_ensemble = production_ensemble if production_ensemble is not None else ensemble
         self.production_friction = production_friction if production_friction is not None else friction
@@ -371,13 +391,14 @@ class MDCalculator:
                 rng=self.rng,
             )
         elif ensemble.lower() == 'npt':
+            externalstress, pfactor = self._npt_barostat_params(pressure, bulk_modulus)
             self.dyn = NPT(
                 self.atoms,
                 timestep * units.fs,
                 temperature_K=temperature,
-                externalstress=pressure,
+                externalstress=externalstress,
                 ttime=25*units.fs,
-                pfactor=75*units.fs**2,
+                pfactor=pfactor,
             )
         elif ensemble.lower() == 'nve':
             from ase.md.verlet import VelocityVerlet
@@ -554,13 +575,15 @@ class MDCalculator:
                     rng=self.rng,
                 )
             elif self.production_ensemble.lower() == 'npt':
+                externalstress, pfactor = self._npt_barostat_params(
+                    self.pressure, self.bulk_modulus)
                 self.dyn = NPT(
                     self.atoms,
                     self.timestep * units.fs,
                     temperature_K=self.temperature,
-                    externalstress=self.pressure,
+                    externalstress=externalstress,
                     ttime=25*units.fs,
-                    pfactor=75*units.fs**2,
+                    pfactor=pfactor,
                 )
             elif self.production_ensemble.lower() == 'nve':
                 from ase.md.verlet import VelocityVerlet

--- a/src/pyslice/multislice/calculators.py
+++ b/src/pyslice/multislice/calculators.py
@@ -11,7 +11,7 @@ from .multislice import Probe, PrismProbe, Propagate, create_batched_probes
 from .trajectory import Trajectory
 from ..postprocessing.wf_data import WFData
 from .sed import SED
-from pyslice.backend import make_backend, to_numpy, NumpyBackend
+from pyslice.backend import make_backend, to_numpy, NumpyBackend, source_files_version
 
 logger = logging.getLogger(__name__)
 
@@ -50,10 +50,16 @@ class MultisliceCalculator:
             30: 'Zn', 31: 'Ga', 32: 'Ge', 33: 'As', 34: 'Se', 35: 'Br', 36: 'Kr'
         }
 
-    # Bump whenever a change to propagation / potential / probe code alters the
-    # cached wavefunction VALUES, so that stale psi_data from an older version
-    # is not silently reloaded as if it were current.
-    _CACHE_VERSION = 2
+    # Derived automatically from the sources whose logic determines the cached
+    # wavefunction VALUES, so any change to propagation / potential / probe /
+    # backend code changes the key and stale psi_data is not silently reused.
+    # The "v3" prefix allows a manual bump for reasons outside these files.
+    _CACHE_VERSION = "v3-" + source_files_version([
+        os.path.join(os.path.dirname(__file__), "multislice.py"),
+        os.path.join(os.path.dirname(__file__), "potentials.py"),
+        os.path.join(os.path.dirname(__file__), "calculators.py"),
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), "backend.py"),
+    ])
 
     def _generate_cache_key(self, trajectory, aperture, voltage_eV,
                             slice_thickness, sampling, probe_positions,

--- a/src/pyslice/multislice/calculators.py
+++ b/src/pyslice/multislice/calculators.py
@@ -50,24 +50,45 @@ class MultisliceCalculator:
             30: 'Zn', 31: 'Ga', 32: 'Ge', 33: 'As', 34: 'Se', 35: 'Br', 36: 'Kr'
         }
 
+    # Bump whenever a change to propagation / potential / probe code alters the
+    # cached wavefunction VALUES, so that stale psi_data from an older version
+    # is not silently reloaded as if it were current.
+    _CACHE_VERSION = 2
+
     def _generate_cache_key(self, trajectory, aperture, voltage_eV,
                             slice_thickness, sampling, probe_positions,
                             spatial_decoherence, temporal_decoherence,
                             probe_array=None, stored_layer_indices=None):
-        """Generate a short hash for parameters that affect wavefunction output."""
-        firstNAtoms = [str(np.round(v, 4)) for v in trajectory.positions[0, :100, 0]]  # first timestep's first 10 atom's x positions
+        """Generate a short hash for parameters that affect wavefunction output.
+
+        The trajectory is hashed in full (every frame, atom and component)
+        rather than sampled from frame 0, so runs that differ only in later
+        frames or in y/z — e.g. a temperature/seed sweep from the same initial
+        structure — get distinct caches instead of silently sharing one.
+        """
+        def _hash_array(a):
+            return hashlib.md5(
+                np.ascontiguousarray(to_numpy(a)).tobytes()).hexdigest()
+
         params = {
-            'firstNAtoms': ",".join(firstNAtoms),  # WHY? prevents the same script from re-using psi_data when positions change
+            'cache_version': self._CACHE_VERSION,
+            'traj_positions': _hash_array(trajectory.positions),
             'n_frames': trajectory.n_frames,
             'n_atoms': trajectory.n_atoms,
-            'box_matrix': trajectory.box_matrix.tolist(),
-            'atom_types': trajectory.atom_types.tolist(),
+            'box_matrix': np.asarray(trajectory.box_matrix).tolist(),
+            'atom_types': np.asarray(trajectory.atom_types).tolist(),
             'aperture': aperture,
             'voltage_eV': voltage_eV,
             'slice_thickness': slice_thickness,
             'sampling': sampling,
-            'probe_positions': probe_positions,
-            'backend': 'torch' if self._backend.xp is not np else 'numpy',
+            'probe_positions': np.asarray(probe_positions).tolist(),
+            'kth': self.kth,
+            'max_kx': self.max_kx,
+            'max_ky': self.max_ky,
+            'min_dk': self.min_dk,
+            'prism': self.prism,
+            'slice_axis': self.slice_axis,
+            'backend': 'torch' if not isinstance(self._backend, NumpyBackend) else 'numpy',
         }
         if stored_layer_indices is not None:
             params['stored_layer_indices'] = tuple(stored_layer_indices)
@@ -76,8 +97,9 @@ class MultisliceCalculator:
         if temporal_decoherence is not None:
             params['temporal_decoherence'] = temporal_decoherence
         if probe_array is not None:
-            probe_np = np.ascontiguousarray(to_numpy(probe_array).ravel()[:1000])
-            params['probe_hash'] = hashlib.md5(probe_np.tobytes()).hexdigest()
+            # Hashing the full probe array captures defocus, aberrations,
+            # decoherence and the aperture/crop geometry baked into the probe.
+            params['probe_hash'] = _hash_array(probe_array)
         param_str = str(sorted(params.items()))
         return hashlib.md5(param_str.encode()).hexdigest()[:12]
 

--- a/src/pyslice/multislice/calculators.py
+++ b/src/pyslice/multislice/calculators.py
@@ -495,7 +495,10 @@ class MultisliceCalculator:
             self.ADF = HAADFData(wf)
             self.ADFmask = b.absolute(self.ADF.getMask(**kwargs))  # HAADFData infers mask dtype from _wf_array dtype, but we'll absolute^2 later
             self.ADFindex = b.astype(b.absolute(self.ADF._wf_array[0, :, :, 0, 0, 0, 0]), int)
-            self.ADF._array = b.zeros(self.ADFindex.shape, dtype=self.complex_dtype)
+            # One ADF image per stored layer (thickness). Collapsed to a plain 2D
+            # image below when only one thickness is stored (the default).
+            self.ADF._array = b.zeros((self.n_layers,) + tuple(self.ADFindex.shape),
+                                      dtype=self.complex_dtype)
 
         # If tacaw.npy already exists and no per-frame cache will be written,
         # there is nothing to reload or recompute. Pass force_rerun=True to
@@ -535,8 +538,11 @@ class MultisliceCalculator:
                     expected_n_layers=self.n_layers,
                 )
                 if cache_exists and not self.prism and self.ADF:
-                    intensities = b.einsum('pxyln,xy->p', b.absolute(frame_data)**2, self.ADFmask)
-                    self.ADF._array += intensities[self.ADFindex]
+                    # Keep the layer axis so each stored thickness gets its own
+                    # ADF image (previously all layers were summed together).
+                    intensities = b.einsum('pxyln,xy->pl', b.absolute(frame_data)**2, self.ADFmask)
+                    for out_idx in range(self.n_layers):
+                        self.ADF._array[out_idx] += intensities[self.ADFindex, out_idx]
 
                 if not os.path.exists(self.output_dir / f"kx.npy"):
                     np.save(self.output_dir / f"kx.npy", to_numpy(self.kxs[self.keep_kxs_indices]))
@@ -622,8 +628,16 @@ class MultisliceCalculator:
                                 frame_data[selected, :, :, out_idx, 0] = diffraction_patterns  # load p,x,y --> p,x,y,l,1 indices
                             if self.ADF and not self.prism:
                                 intensities = b.einsum('pxy,xy->p', b.absolute(diffraction_patterns[:, :, :])**2, self.ADFmask)
+                                # The batch is (nc, npt) flattened as c*npt+p, so
+                                # fold the decoherence copies back and sum them
+                                # (the detector sees the incoherent sum). The old
+                                # zip() truncated to the first copy only.
+                                n_copies = intensities.shape[0] // len(selected)
+                                if n_copies > 1:
+                                    intensities = b.sum(
+                                        b.reshape(intensities, (n_copies, len(selected))), axis=0)
                                 for i, pp in zip(intensities, selected):
-                                    self.ADF._array[self.ADFindex==pp] += i
+                                    self.ADF._array[out_idx][self.ADFindex == pp] += i
                         if pbar2 is not None:
                             pbar2.update(len(selected))
 
@@ -716,7 +730,12 @@ class MultisliceCalculator:
             logger.info(f"Cache files saved in: {self.output_dir}")
 
         if self.ADF:
-            self.ADF._array /= self.n_frames  # haadf_data divides by nc,nt,nl (from _wf_array's c,x,y,t,kx,ky,l)
+            self.ADF._array /= self.n_frames  # per-thickness time average
+            # Depth (Å) of each ADF image (the z of its stored slice), and
+            # collapse to a plain 2D image when a single thickness was stored.
+            self.ADF.thicknesses = to_numpy(self.zs)[list(_stored_layers)]
+            if self.n_layers == 1:
+                self.ADF._array = self.ADF._array[0]
             return wf_data, self.ADF
 
         return wf_data

--- a/src/pyslice/multislice/calculators.py
+++ b/src/pyslice/multislice/calculators.py
@@ -258,14 +258,49 @@ class MultisliceCalculator:
 
         # Preferred to pass probe_xs and probe_ys from which we will define a grid
         if self.probe_xs is not None and self.probe_ys is not None:
+            if self.probe_positions is not None:
+                logger.warning(
+                    "Both probe_xs/probe_ys and probe_positions were supplied; "
+                    "probe_positions is ignored in favour of the "
+                    "probe_xs x probe_ys grid."
+                )
             x, y = np.meshgrid(self.probe_xs, self.probe_ys)
             self.probe_positions = np.reshape([x, y], (2, len(x.flat))).T  # x,y looped indices to match what multislice.Probe does
 
-        # If probe_positions provided but not probe_xs/probe_ys, derive them
+        # If probe_positions provided but not probe_xs/probe_ys, derive the scan
+        # coordinates.  probe_xs/probe_ys are the unique coordinates used to
+        # reshape the flat probe axis into a 2D image (WFData.reshaped / HAADF),
+        # which assumes the meshgrid flattening order (x fastest, y outer).
         elif self.probe_positions is not None:
-            positions = np.asarray(self.probe_positions)
+            positions = np.asarray(self.probe_positions, dtype=float)
+            if positions.ndim != 2 or positions.shape[1] != 2:
+                raise ValueError(
+                    "probe_positions must be a sequence of (x, y) pairs with "
+                    f"shape (N, 2); got array of shape {positions.shape}."
+                )
             self.probe_xs = sorted(list(set(positions[:, 0])))
             self.probe_ys = sorted(list(set(positions[:, 1])))
+            gx, gy = np.meshgrid(self.probe_xs, self.probe_ys)
+            grid = np.reshape([gx, gy], (2, gx.size)).T
+            pos_set = {(round(px, 6), round(py, 6)) for px, py in positions}
+            grid_set = {(round(px, 6), round(py, 6)) for px, py in grid}
+            if len(positions) == len(grid) and pos_set == grid_set:
+                # The points tile a full rectangular grid: canonicalise their
+                # order to the meshgrid flattening so the 2D image maps correctly
+                # regardless of the order they were passed in (e.g. a nested
+                # [(x, y) for x in xs for y in ys] loop).
+                self.probe_positions = grid
+            else:
+                # Arbitrary point set (e.g. site-resolved TACAW on selected
+                # columns): simulate exactly as given.  Per-probe spectra are
+                # correct, but 2D image reshaping cannot apply.
+                self.probe_positions = positions
+                logger.warning(
+                    "probe_positions (%d points) do not form a full %d x %d "
+                    "grid; per-probe spectra are correct but image reshaping "
+                    "(HAADFData/spectrum_image) will not apply.",
+                    len(positions), len(self.probe_xs), len(self.probe_ys),
+                )
 
         # Set up default probe position if not provided
         if self.probe_positions is None:
@@ -278,7 +313,12 @@ class MultisliceCalculator:
         else:
             # OR, we'll propagate our series of real-space probes.
             # need to make sure they're on the correct device, and defer_shifts=True means the calculator controls when to expand the probe cube (see loop_probes)
-            self.base_probe = Probe(xs, ys, self.aperture, self.voltage_eV, backend=b, probe_xs=self.probe_xs, probe_ys=self.probe_ys, probe_positions=self.probe_positions, cropping=self.probe_cropping, defer_shifts=True)
+            # Pass the canonical probe_positions directly (already meshed in the
+            # probe_xs/probe_ys branch above).  Passing probe_xs/probe_ys here
+            # would make Probe rebuild an outer-product grid, so an explicit
+            # position list would be silently replaced by that grid and desync
+            # n_probes from the actually-simulated probes (shape-mismatch crash).
+            self.base_probe = Probe(xs, ys, self.aperture, self.voltage_eV, backend=b, probe_positions=self.probe_positions, cropping=self.probe_cropping, defer_shifts=True)
 
         defocus_values = to_numpy(self.defocus)
         if np.ndim(defocus_values) != 0:

--- a/src/pyslice/multislice/calculators.py
+++ b/src/pyslice/multislice/calculators.py
@@ -64,7 +64,8 @@ class MultisliceCalculator:
     def _generate_cache_key(self, trajectory, aperture, voltage_eV,
                             slice_thickness, sampling, probe_positions,
                             spatial_decoherence, temporal_decoherence,
-                            probe_array=None, stored_layer_indices=None):
+                            probe_array=None, stored_layer_indices=None,
+                            skip_vacuum=False):
         """Generate a short hash for parameters that affect wavefunction output.
 
         The trajectory is hashed in full (every frame, atom and component)
@@ -94,6 +95,7 @@ class MultisliceCalculator:
             'min_dk': self.min_dk,
             'prism': self.prism,
             'slice_axis': self.slice_axis,
+            'skip_vacuum': bool(skip_vacuum),
             'backend': 'torch' if not isinstance(self._backend, NumpyBackend) else 'numpy',
         }
         if stored_layer_indices is not None:
@@ -387,6 +389,7 @@ class MultisliceCalculator:
             self.base_probe.spatial_decoherence, self.base_probe.temporal_decoherence,
             self.base_probe._array,
             self._cache_key_stored_layers(self._stored_layers),
+            self.skip_vacuum,
         )
         self.output_dir = Path("psi_data/" + ("torch" if not isinstance(b, NumpyBackend) else "numpy") + "_"+self.cache_key)
 
@@ -436,7 +439,8 @@ class MultisliceCalculator:
                                              self.slice_thickness, self.sampling, self.probe_positions,
                                              self.base_probe.spatial_decoherence, self.base_probe.temporal_decoherence,
                                              self.base_probe._array,
-                                             self._cache_key_stored_layers(_stored_layers))
+                                             self._cache_key_stored_layers(_stored_layers),
+                                             self.skip_vacuum)
         if self.cache_key != cache_key:
             self.cache_key = cache_key
         self.output_dir = Path("psi_data/" + ("torch" if b.xp is not np else "numpy") + "_"+cache_key)
@@ -536,11 +540,14 @@ class MultisliceCalculator:
                     self.cache_wavefunctions and not force_rerun,
                     b,
                     expected_n_layers=self.n_layers,
+                    expected_n_probes=self.n_probes,
                 )
                 if cache_exists and not self.prism and self.ADF:
                     # Keep the layer axis so each stored thickness gets its own
                     # ADF image (previously all layers were summed together).
                     intensities = b.einsum('pxyln,xy->pl', b.absolute(frame_data)**2, self.ADFmask)
+                    intensities = b.sum(
+                        b.reshape(intensities, (nc, npt, self.n_layers)), axis=0)
                     for out_idx in range(self.n_layers):
                         self.ADF._array[out_idx] += intensities[self.ADFindex, out_idx]
 
@@ -566,7 +573,11 @@ class MultisliceCalculator:
 
                     nc, npt, nx, ny = self.base_probe._array.shape; npt = len(self.base_probe.probe_positions)
                     n_slices = len(self.zs)
-                    n_waves = len(self.base_probe.probe_positions)
+                    # Real-space propagation flattens decoherence copies into
+                    # the wave axis. PRISM stores its Fourier components here
+                    # instead and reconstructs real-space probes afterwards.
+                    n_waves = (len(self.base_probe.probe_positions)
+                               if self.prism else self.n_probes)
 
                     # frame_data is always: p,x,y,l,1 (self.wavefunction_data expects p,t,x,y,l, since we loop time. recall Propagate gave l,p,x,y)
                     if self.returns_wavefunctions or self.cache_wavefunctions or self.prism:
@@ -625,7 +636,16 @@ class MultisliceCalculator:
                                 diffraction_patterns = to_numpy(diffraction_patterns)
                                 selected = to_numpy(selected)
                             if self.returns_wavefunctions or self.cache_wavefunctions or self.prism:
-                                frame_data[selected, :, :, out_idx, 0] = diffraction_patterns  # load p,x,y --> p,x,y,l,1 indices
+                                # Propagation flattens (copy, selected-probe) in
+                                # copy-major order. Expand the selected position
+                                # indices across copies to preserve that layout.
+                                if self.use_memmap:
+                                    selected_rows = np.reshape(
+                                        np.arange(nc)[:, None] * npt + selected[None, :], (-1,))
+                                else:
+                                    selected_rows = b.reshape(
+                                        b.arange(nc)[:, None] * npt + selected[None, :], (-1,))
+                                frame_data[selected_rows, :, :, out_idx, 0] = diffraction_patterns
                             if self.ADF and not self.prism:
                                 intensities = b.einsum('pxy,xy->p', b.absolute(diffraction_patterns[:, :, :])**2, self.ADFmask)
                                 # The batch is (nc, npt) flattened as c*npt+p, so
@@ -734,6 +754,9 @@ class MultisliceCalculator:
             # Depth (Å) of each ADF image (the z of its stored slice), and
             # collapse to a plain 2D image when a single thickness was stored.
             self.ADF.thicknesses = to_numpy(self.zs)[list(_stored_layers)]
+            self.ADF._set_dimensions(
+                self.ADF.thicknesses if self.n_layers > 1 else None,
+                layer_name='thickness', layer_units='Å')
             if self.n_layers == 1:
                 self.ADF._array = self.ADF._array[0]
             return wf_data, self.ADF
@@ -743,7 +766,8 @@ class MultisliceCalculator:
 
 logging_tracker = []
 
-def checkCache(cache_file, cache_wavefunctions, b, expected_n_layers=None):
+def checkCache(cache_file, cache_wavefunctions, b, expected_n_layers=None,
+               expected_n_probes=None):
     global logging_tracker
     if cache_wavefunctions and cache_file.exists():
         frame_data = np.load(cache_file)
@@ -753,6 +777,12 @@ def checkCache(cache_file, cache_wavefunctions, b, expected_n_layers=None):
                 frame_data.shape[-2],
                 cache_file,
                 expected_n_layers,
+            )
+            return False, 0
+        if expected_n_probes is not None and frame_data.shape[0] != expected_n_probes:
+            logging.warning(
+                "Ignoring cache with %d probes at %s; expected %d",
+                frame_data.shape[0], cache_file, expected_n_probes,
             )
             return False, 0
         parent = str(cache_file.parent)

--- a/src/pyslice/multislice/calculators.py
+++ b/src/pyslice/multislice/calculators.py
@@ -216,6 +216,15 @@ class MultisliceCalculator:
         self.probe_positions = probe_positions
         self.save_path = save_path
         self.cleanup_temp_files = cleanup_temp_files
+        if slice_axis != 2:
+            # Propagation is hard-coded to the z axis; any other slice_axis
+            # silently produces wrong results (see Potential). Fail early with
+            # guidance rather than after a full run.
+            raise NotImplementedError(
+                "slice_axis != 2 is not supported (it would silently produce "
+                "wrong results). Permute your trajectory so the beam direction "
+                "is the z axis and use slice_axis=2."
+            )
         self.slice_axis = slice_axis
         self.return_layers = return_layers
         self.cache_wavefunctions = cache_wavefunctions

--- a/src/pyslice/multislice/calculators.py
+++ b/src/pyslice/multislice/calculators.py
@@ -464,7 +464,14 @@ class MultisliceCalculator:
             print("filtered to", len(self.probe_indices), "probe positions")
 
         nc, npt, nx, ny = self.base_probe._array.shape
-        self.n_probes = nc*len(self.probe_positions)
+        n_scan_positions = len(self.probe_positions)
+        self.n_probes = nc*n_scan_positions
+        # Real-space frame caches store one row per incoherent-copy/scan pair.
+        # PRISM caches instead store one row per propagated Fourier component.
+        expected_cache_rows = (
+            len(self.base_probe.probe_positions) if self.prism
+            else self.n_probes
+        )
         # Storage: [probe, frame, x, y, layer] - matches WFData expected format
         self.n_layers = len(_stored_layers)
         stores_exit_wave_only = self._stores_exit_wave_only(_stored_layers)
@@ -540,14 +547,20 @@ class MultisliceCalculator:
                     self.cache_wavefunctions and not force_rerun,
                     b,
                     expected_n_layers=self.n_layers,
-                    expected_n_probes=self.n_probes,
+                    expected_n_probes=expected_cache_rows,
                 )
                 if cache_exists and not self.prism and self.ADF:
                     # Keep the layer axis so each stored thickness gets its own
                     # ADF image (previously all layers were summed together).
                     intensities = b.einsum('pxyln,xy->pl', b.absolute(frame_data)**2, self.ADFmask)
+                    n_copies = frame_data.shape[0] // n_scan_positions
                     intensities = b.sum(
-                        b.reshape(intensities, (nc, npt, self.n_layers)), axis=0)
+                        b.reshape(
+                            intensities,
+                            (n_copies, n_scan_positions, self.n_layers),
+                        ),
+                        axis=0,
+                    )
                     for out_idx in range(self.n_layers):
                         self.ADF._array[out_idx] += intensities[self.ADFindex, out_idx]
 
@@ -676,7 +689,7 @@ class MultisliceCalculator:
                     if self.ADF:
                         kwarg["ADF"] = (self.ADF, self.ADFmask, self.ADFindex)
                     if self.returns_wavefunctions:
-                        kwarg["load_into"] = self.wavefunction_data[:, frame_idx, :, :, 0]
+                        kwarg["load_into"] = self.wavefunction_data[:, frame_idx, :, :, :]
                     self.base_probe.calculateProbesFromS(frame_data, self.probe_positions, **kwarg, chunksize=self.loop_probes)
                 elif self.returns_wavefunctions:
                     if self.use_memmap:
@@ -751,9 +764,13 @@ class MultisliceCalculator:
 
         if self.ADF:
             self.ADF._array /= self.n_frames  # per-thickness time average
-            # Depth (Å) of each ADF image (the z of its stored slice), and
+            # Each stored wave is captured after that slice's transmission, so
+            # its depth is the far boundary (i + 1) * dz, not the slice's
+            # coordinate sample zs[i]. The final layer must equal specimen lz.
             # collapse to a plain 2D image when a single thickness was stored.
-            self.ADF.thicknesses = to_numpy(self.zs)[list(_stored_layers)]
+            dz = float(self.lz) / len(self.zs)
+            self.ADF.thicknesses = (
+                np.asarray(_stored_layers, dtype=float) + 1.0) * dz
             self.ADF._set_dimensions(
                 self.ADF.thicknesses if self.n_layers > 1 else None,
                 layer_name='thickness', layer_units='Å')

--- a/src/pyslice/multislice/multislice.py
+++ b/src/pyslice/multislice/multislice.py
@@ -803,25 +803,31 @@ class PrismProbe:
         blowing up RAM with a full (n_positions × nkx × nky) intermediate.
 
         array shape on input: (n_sinusoids, nkx, nky, n_layers, 1)
-            reshaped to:      (nx_cropped, ny_cropped, nkx, nky)
+            reshaped to:      (nx_cropped, ny_cropped, nkx, nky, n_layers)
         """
         b = self._backend
 
-        if load_into is None and not ADF:
-            result = b.zeros(
-                (len(positions), b.ceil(self.nx / self.kth), b.ceil(self.ny / self.kth)),
-                dtype=b.complex_dtype,
-            )
-        elif not ADF:
+        npt, nkx, nky, n_layers, _ = array.shape
+        adf_data = None
+        if ADF:
+            adf_data, ADFmask, ADFindex = ADF
+
+        if load_into is not None:
             result = load_into
+        elif adf_data is None:
+            result_shape = (len(positions), nkx, nky)
+            if n_layers > 1:
+                result_shape += (n_layers,)
+            result = b.zeros(result_shape, dtype=b.complex_dtype)
         else:
-            ADF, ADFmask, ADFindex = ADF
             result = None
 
-        npt, nkx, nky, _, _ = array.shape
         # Reshape from (sinusoid_index, kx, ky, layer, 1)
-        # to (nx_cropped, ny_cropped, kx, ky) for einsum below.
-        array = b.reshape(array, (self.nx_cropped, self.ny_cropped, nkx, nky))
+        # to (nx_cropped, ny_cropped, kx, ky, layer) for einsum below.
+        array = b.reshape(
+            array,
+            (self.nx_cropped, self.ny_cropped, nkx, nky, n_layers),
+        )
 
         chunksize = max(1, chunksize)
         for n, (x, y) in enumerate(tqdm(positions)):
@@ -849,18 +855,25 @@ class PrismProbe:
 
             # Reconstruct the exit wave:  Σ_{kx_n, ky_n} factors · S_n(kx, ky)
             # Indices: p=probe chunk, k=sparse kx, q=sparse ky, x=full kx, y=full ky
-            chunked = b.einsum('pkq,kqxy->pxy', factors, array)
+            chunked = b.einsum('pkq,kqxyl->pxyl', factors, array)
 
             if isinstance(result, np.memmap):
                 chunked = to_numpy(chunked)
 
-            if ADF:
+            if adf_data is not None:
                 intensities = b.einsum(
-                    'pxy,xy->p', b.absolute(chunked)**2, ADFmask)
-                for intensity, pp in zip(intensities, range(n, n + chunksize)):
-                    ADF._array[ADFindex == pp] += intensity
-            else:
-                result[n:n + chunksize, :, :] = chunked
+                    'pxyl,xy->pl', b.absolute(chunked)**2, ADFmask)
+                for probe_intensities, pp in zip(
+                    intensities, range(n, n + chunksize)
+                ):
+                    for layer_index, intensity in enumerate(probe_intensities):
+                        adf_data._array[layer_index][ADFindex == pp] += intensity
+
+            if result is not None:
+                if len(result.shape) == 3:
+                    result[n:n + chunksize, :, :] = chunked[:, :, :, 0]
+                else:
+                    result[n:n + chunksize, :, :, :] = chunked
 
         return result
 

--- a/src/pyslice/multislice/multislice.py
+++ b/src/pyslice/multislice/multislice.py
@@ -389,7 +389,13 @@ class Probe:
 
         for i, (px, py) in enumerate(self.probe_positions):
             if px - self.lx / 2 == 0 and py - self.ly / 2 == 0:
-                continue   # already centred
+                # Already centred: no phase ramp needed, but a cropped probe's
+                # window still begins at the crop origin (i1, j1), not the grid
+                # corner (0, 0), so record that offset for Propagate.
+                if self.cropping:
+                    self.offsets[i, 0] = self.nx // 2 - self.cropping // 2
+                    self.offsets[i, 1] = self.ny // 2 - self.cropping // 2
+                continue
             self._array[:, i, :, :], (dpx, dpy) = self.placeProbe(
                 self._array[:, i, :, :], px, py)
             self.offsets[i, 0] = int(dpx)
@@ -1049,11 +1055,19 @@ def Propagate(
             # probe position without allocating a full (npt, nx, ny) array.
             nx_full, ny_full = potential_slice.shape
             xr = b.arange(nx_full); yr = b.arange(ny_full)
-            xi = b.zeros((len(sigma), probe.cropping), dtype=int)
-            yi = b.zeros((len(sigma), probe.cropping), dtype=int)
-            for p, (ox, oy) in enumerate(probe.offsets):
-                xi[p, :] = b.roll(xr, -ox)[:probe.cropping]
-                yi[p, :] = b.roll(yr, -oy)[:probe.cropping]
+            n_batch = len(sigma)
+            npt_off = probe.offsets.shape[0]
+            xi = b.zeros((n_batch, probe.cropping), dtype=int)
+            yi = b.zeros((n_batch, probe.cropping), dtype=int)
+            # The batch axis flattens (nc, npt) as c*npt + p (see reshape above),
+            # so batch row bi belongs to probe position bi % npt and must use
+            # that position's window offset — shared across all nc coherent
+            # copies.  (Previously only the first npt rows were filled, so every
+            # decoherence copy beyond the first read the grid-corner window.)
+            for bi in range(n_batch):
+                ox, oy = probe.offsets[bi % npt_off]
+                xi[bi, :] = b.roll(xr, -int(ox), 0)[:probe.cropping]
+                yi[bi, :] = b.roll(yr, -int(oy), 0)[:probe.cropping]
             # Advanced indexing: pot_stack[p, i, j] = potential_slice[xi[p,i], yi[p,j]]
             pot_stack = potential_slice[xi[:, :, None], yi[:, None, :]]
             t = b.exp(1j * sigma[:, None, None] * pot_stack)

--- a/src/pyslice/multislice/multislice.py
+++ b/src/pyslice/multislice/multislice.py
@@ -501,16 +501,26 @@ class Probe:
         is always: temporal → spatial → shift.
         """
         b = self._backend
+        if sigma_eV <= 0:
+            raise ValueError("sigma_eV must be positive")
+        if not isinstance(N, (int, np.integer)) or N < 1:
+            raise ValueError("N must be a positive integer")
         nc, npt, nx, ny = self._array.shape
         if self.temporal_decoherence is not None:
             logger.warning("addTemporalDecoherence called twice — overwriting previous.")
         self.temporal_decoherence = (sigma_eV, N)
 
-        self.eVs        = b.asarray(b.linspace(self.eV - 2*sigma_eV,
-                                                self.eV + 2*sigma_eV, N),
+        energy_samples = ([self.eV] if N == 1 else
+                          b.linspace(self.eV - 2*sigma_eV,
+                                     self.eV + 2*sigma_eV, N))
+        self.eVs        = b.asarray(energy_samples,
                                     dtype=b.float_dtype)
         self.wavelengths = wavelength(self.eVs, b)
         amplitudes       = b.exp(-(self.eV - self.eVs)**2 / sigma_eV**2)
+        # These copies are combined incoherently, so their intensity weights
+        # must sum to one. Without this normalisation the total dose grew with
+        # N (and happened to look correct only for N=3, whose centre dominates).
+        amplitudes /= b.sqrt(b.sum(amplitudes**2))
 
         # Rebuilding the template from scratch discards any prior positioning,
         # so allow the applyShifts() call below to run again.
@@ -540,13 +550,20 @@ class Probe:
         the expanded nc dimension has the correct associated value.
         """
         b = self._backend
+        if sigma_dz <= 0:
+            raise ValueError("sigma_dz must be positive")
+        if not isinstance(N, (int, np.integer)) or N < 1:
+            raise ValueError("N must be a positive integer")
         if self.spatial_decoherence is not None:
             logger.warning("addSpatialDecoherence called twice — overwriting previous.")
         self.spatial_decoherence = (sigma_dz, N)
 
-        dzs        = b.asarray(b.linspace(-2*sigma_dz, 2*sigma_dz, N),
+        defocus_samples = ([0.0] if N == 1 else
+                           b.linspace(-2*sigma_dz, 2*sigma_dz, N))
+        dzs        = b.asarray(defocus_samples,
                                dtype=b.float_dtype)
         amplitudes = b.exp(-dzs**2 / sigma_dz**2)
+        amplitudes /= b.sqrt(b.sum(amplitudes**2))
 
         nc, npt, nx, ny = self._array.shape
         self.defocus(dzs)   # expands: (nc,1,nx,ny) → (N·nc,1,nx,ny)

--- a/src/pyslice/multislice/multislice.py
+++ b/src/pyslice/multislice/multislice.py
@@ -267,6 +267,11 @@ class Probe:
         # Pixel offsets used when probe is cropped to a sub-region.
         self.offsets = np.zeros((len(self.probe_positions), 2), dtype=int)
 
+        # Whether applyShifts() has already positioned the probes.  Re-applying
+        # the position phase ramp would displace each probe by the requested
+        # offset a second time, so applyShifts() is a no-op once this is set.
+        self._shifts_applied = False
+
         if not defer_shifts:
             self.applyShifts()
 
@@ -361,8 +366,10 @@ class Probe:
         """
         b = self._backend
         nc, npt, nx, ny = self._array.shape
-        if npt > 1:
-            # Shifts have already been applied — nothing to do.
+        if self._shifts_applied or npt > 1:
+            # Shifts already applied — re-applying would displace each probe by
+            # its requested offset a second time (compounding on every frame in
+            # run()).  npt > 1 additionally guards an already-expanded array.
             return
 
         # Broadcast the single template probe to all npt positions.
@@ -387,6 +394,8 @@ class Probe:
                 self._array[:, i, :, :], px, py)
             self.offsets[i, 0] = int(dpx)
             self.offsets[i, 1] = int(dpy)
+
+        self._shifts_applied = True
 
     def placeProbe(self, array, x: float, y: float):
         """
@@ -497,6 +506,9 @@ class Probe:
         self.wavelengths = wavelength(self.eVs, b)
         amplitudes       = b.exp(-(self.eV - self.eVs)**2 / sigma_eV**2)
 
+        # Rebuilding the template from scratch discards any prior positioning,
+        # so allow the applyShifts() call below to run again.
+        self._shifts_applied = False
         self._array = b.zeros((N, 1, nx, ny), dtype=b.complex_dtype)
         for n, eV_n in enumerate(self.eVs):
             lam_n = wavelength(eV_n, b)
@@ -600,6 +612,11 @@ class Probe:
             new_probe.probe_positions = np.asarray(self.probe_positions)[sel, :]
         else:
             new_probe._array = b.clone(self._array)
+
+        # Inherit positioning state: a copy of an already-shifted probe must not
+        # be shifted again, while a copy of the unshifted template (the
+        # loop_probes path) still needs applyShifts().
+        new_probe._shifts_applied = self._shifts_applied
 
         return new_probe
 

--- a/src/pyslice/multislice/potentials.py
+++ b/src/pyslice/multislice/potentials.py
@@ -210,6 +210,19 @@ class Potential:
         # Slice-axis geometry
         # ----------------------------------------------------------------
         self.slice_axis = slice_axis
+        if slice_axis != 2:
+            # The propagator, slice spacing (dz), slice loop and reciprocal grid
+            # in Propagate are all hard-coded to the z axis, and the (nx, ny)
+            # reciprocal grid here is built from the x/y axes regardless of
+            # slice_axis. A non-z value therefore lays the wrong coordinate onto
+            # the grid and propagates with the wrong spacing, silently producing
+            # wrong results. Permute the trajectory/grid so the beam direction
+            # is z (axis 2) and keep the default slice_axis=2.
+            raise NotImplementedError(
+                "slice_axis != 2 is not supported (it would silently produce "
+                "wrong results). Permute your trajectory so the beam direction "
+                "is the z axis and use slice_axis=2."
+            )
         inplane = [a for a in range(3) if a != slice_axis]
         self.inplane_axis1, self.inplane_axis2 = inplane
 

--- a/src/pyslice/multislice/trajectory.py
+++ b/src/pyslice/multislice/trajectory.py
@@ -273,24 +273,30 @@ class Trajectory:
         if mean_pos.shape[0] == 0:
             return self
 
-        # Apply filters
+        # Apply filters. The box is shrunk to each range's width, so the kept
+        # atoms must also be translated by the range lower bound; otherwise they
+        # keep their original coordinates and fall outside the new [0, width) box.
         atom_mask = np.ones(self.n_atoms, dtype=bool)
         new_box = self.box_matrix.copy()
+        origin_shift = np.zeros(3, dtype=self.positions.dtype)
 
         if x_range is not None:
             min_x, max_x = x_range
             atom_mask &= (mean_pos[:, 0] >= min_x) & (mean_pos[:, 0] <= max_x)
             new_box[0, 0] = max_x - min_x
+            origin_shift[0] = min_x
 
         if y_range is not None:
             min_y, max_y = y_range
             atom_mask &= (mean_pos[:, 1] >= min_y) & (mean_pos[:, 1] <= max_y)
             new_box[1, 1] = max_y - min_y
+            origin_shift[1] = min_y
 
         if z_range is not None:
             min_z, max_z = z_range
             atom_mask &= (mean_pos[:, 2] >= min_z) & (mean_pos[:, 2] <= max_z)
             new_box[2, 2] = max_z - min_z
+            origin_shift[2] = min_z
 
         # Check results
         n_filtered = np.sum(atom_mask)
@@ -304,10 +310,10 @@ class Trajectory:
         if n_filtered == self.n_atoms:
             return self
 
-        # Create filtered trajectory
+        # Create filtered trajectory, translating kept atoms into the new box.
         return Trajectory(
             atom_types=self.atom_types[atom_mask],
-            positions=self.positions[:, atom_mask, :],
+            positions=self.positions[:, atom_mask, :] - origin_shift,
             velocities=self.velocities[:, atom_mask, :],
             box_matrix=new_box,
             timestep=self.timestep

--- a/src/pyslice/multislice/trajectory.py
+++ b/src/pyslice/multislice/trajectory.py
@@ -307,10 +307,9 @@ class Trajectory:
             if z_range: ranges_desc.append(f"Z∈[{z_range[0]:.2f},{z_range[1]:.2f}]")
             raise ValueError(f"Filter {' AND '.join(ranges_desc)} resulted in 0 atoms")
 
-        if n_filtered == self.n_atoms:
-            return self
-
-        # Create filtered trajectory, translating kept atoms into the new box.
+        # Create the cropped trajectory even when every atom survives. A range
+        # request changes the coordinate origin and box; returning self in that
+        # case silently discarded the requested crop.
         return Trajectory(
             atom_types=self.atom_types[atom_mask],
             positions=self.positions[:, atom_mask, :] - origin_shift,

--- a/src/pyslice/postprocessing/haadf_data.py
+++ b/src/pyslice/postprocessing/haadf_data.py
@@ -52,6 +52,9 @@ class HAADFData(PySliceSerial, Signal):
 
         # Store reference to source WFData array for ADF calculation
         self._wf_array = wf_data.reshaped() # nprobes,x,y,t,kx,ky,l indices
+        # Identity of each stored layer (thickness); used when calculateADF
+        # returns one ADF image per layer.
+        self.layers = getattr(wf_data, '_layer', None)
 
         # Initialize ADF as None, will be computed by calculateADF
         self._array = None
@@ -159,7 +162,11 @@ class HAADFData(PySliceSerial, Signal):
 
         nc,_,_,nt,_,_,nl = self._wf_array.shape
         wf_intensity = b.absolute(self._wf_array)**2 ; mask = b.absolute(mask)
-        self._array = b.einsum('cxytkql,kq->xy', wf_intensity, mask) / (nc*nt*nl)
+        # One ADF image per stored layer (thickness). Only the exit wave
+        # physically reaches the detector, but storing several layers gives ADF
+        # vs thickness. Collapse to a plain 2D image for the single-layer case.
+        stack = b.einsum('cxytkql,kq->lxy', wf_intensity, mask) / (nc*nt)
+        self._array = stack[0] if nl == 1 else stack
 
         xs_np = to_numpy(self._xs)
         ys_np = to_numpy(self._ys)
@@ -177,12 +184,14 @@ class HAADFData(PySliceSerial, Signal):
 
         return self.data  # Return numpy array for backward compatibility
 
-    def plot(self, filename=None, title=None):
+    def plot(self, filename=None, title=None, layer=-1):
         """
         Plot the HAADF image.
 
         Args:
             filename: If provided, save plot to this file instead of displaying
+            layer: Which thickness to plot when the ADF is a per-layer stack
+                (default -1, i.e. the exit wave). Ignored for a single-layer ADF.
         """
         import matplotlib.pyplot as plt
 
@@ -190,7 +199,10 @@ class HAADFData(PySliceSerial, Signal):
             raise RuntimeError("calculateADF() must be called before plotting")
 
         fig, ax = plt.subplots()
-        array = self.array.T[::-1,:]  # imshow convention: y,x. our convention: x,y, and flip y (0,0 upper-left)
+        img = to_numpy(self._array)
+        if img.ndim == 3:            # (n_layers, x, y) stack -> pick a thickness
+            img = img[layer]
+        array = img.T[::-1,:]  # imshow convention: y,x. our convention: x,y, and flip y (0,0 upper-left)
         xs = to_numpy(self._xs)
         ys = to_numpy(self._ys)
 

--- a/src/pyslice/postprocessing/haadf_data.py
+++ b/src/pyslice/postprocessing/haadf_data.py
@@ -62,11 +62,7 @@ class HAADFData(PySliceSerial, Signal):
         self._ys = wf_data.probe_ys
 
         if Dimensions is not None:
-            # Build placeholder dimensions (will be updated after calculateADF)
-            self.dimensions = Dimensions([
-                Dimension(name='x', space='position', units='Å', values=np.array([0])),
-                Dimension(name='y', space='position', units='Å', values=np.array([0])),
-            ], nav_dimensions=[0, 1], sig_dimensions=[])
+            self._set_dimensions()
 
             # Build metadata
             metadata_dict = {
@@ -83,6 +79,37 @@ class HAADFData(PySliceSerial, Signal):
             }
             self.metadata = Metadata(metadata_dict)
             self.sea_type="Signal"
+
+    def _set_dimensions(self, layer_values=None, layer_name='layer',
+                        layer_units=None):
+        """Synchronise Signal dimensions with the current ADF array shape."""
+        if Dimensions is None:
+            return
+        dimensions = []
+        if layer_values is not None:
+            layer_kwargs = {
+                'name': layer_name,
+                'space': 'position',
+                'values': to_numpy(layer_values),
+            }
+            if layer_units is not None:
+                layer_kwargs['units'] = layer_units
+            dimensions.append(Dimension(**layer_kwargs))
+        dimensions.extend([
+            Dimension(name='x', space='position', units='Å',
+                      values=to_numpy(self._xs)),
+            Dimension(name='y', space='position', units='Å',
+                      values=to_numpy(self._ys)),
+        ])
+        dims = Dimensions(
+            dimensions,
+            nav_dimensions=list(range(len(dimensions))),
+            sig_dimensions=[],
+        )
+        # PySEA uses the public dimensions during normal operation and the
+        # local copy during serialisation/deserialisation. Keep both congruent.
+        self.dimensions = dims
+        self._local_dimensions = dims
 
     @property
     def data(self):
@@ -165,17 +192,21 @@ class HAADFData(PySliceSerial, Signal):
         # One ADF image per stored layer (thickness). Only the exit wave
         # physically reaches the detector, but storing several layers gives ADF
         # vs thickness. Collapse to a plain 2D image for the single-layer case.
-        stack = b.einsum('cxytkql,kq->lxy', wf_intensity, mask) / (nc*nt)
+        # Probe copies already carry normalised intensity weights; sum them,
+        # then average only over time. Dividing by nc would make the signal
+        # vanish as more quadrature points are used.
+        stack = b.einsum('cxytkql,kq->lxy', wf_intensity, mask) / nt
         self._array = stack[0] if nl == 1 else stack
 
         xs_np = to_numpy(self._xs)
         ys_np = to_numpy(self._ys)
 
         if Dimensions is not None:
-            self._local_dimensions = Dimensions([
-                Dimension(name='x', space='position', units='Å', values=xs_np),
-                Dimension(name='y', space='position', units='Å', values=ys_np),
-            ], nav_dimensions=[0, 1], sig_dimensions=[])
+            layer_values = None
+            if nl > 1:
+                layer_values = (self.layers if self.layers is not None
+                                else np.arange(nl))
+            self._set_dimensions(layer_values)
 
             # Update metadata with detector settings
             #if hasattr(self.signal.metadata, 'Simulation'):

--- a/src/pyslice/postprocessing/tacaw_data.py
+++ b/src/pyslice/postprocessing/tacaw_data.py
@@ -86,6 +86,22 @@ class TACAWData(PySliceSerial, Signal):
         self._array      = None
         self._frequencies = None
 
+        self.n_scan_positions = len(self.probe_positions)
+        if self.n_scan_positions == 0:
+            raise ValueError("TACAWData requires at least one probe position")
+        n_wave_rows = int(self._wf_array.shape[0])
+        if n_wave_rows % self.n_scan_positions != 0:
+            raise ValueError(
+                "Wavefunction probe rows must be an integer multiple of the "
+                f"{self.n_scan_positions} scan positions; got {n_wave_rows} rows."
+            )
+        self.n_copies = n_wave_rows // self.n_scan_positions
+        if self.keep_complex and self.n_copies > 1:
+            raise ValueError(
+                "keep_complex=True cannot combine incoherent decoherence copies; "
+                "use keep_complex=False to sum their spectral intensities."
+            )
+
         self._fft_from_wf_data(layer_index)
         if self.apply_bose:
             self.apply_bose_correction(self.temperature_K)
@@ -229,7 +245,7 @@ class TACAWData(PySliceSerial, Signal):
         if self.chunkFFT:
             # Memory-conservative path: loop over kx
             dtype = b.complex_dtype if self.keep_complex else b.float_dtype
-            shape = (wf_layer.shape[0], fft_len,
+            shape = (self.n_scan_positions, fft_len,
                      wf_layer.shape[2], wf_layer.shape[3])
             if self.use_memmap:
                 self._array = b.memmap(shape, dtype=dtype,
@@ -245,6 +261,7 @@ class TACAWData(PySliceSerial, Signal):
                     wf_fft  = b.fftshift(b.fft(sl - wf_mean, axes=1), axes=1)
                     if not self.keep_complex:
                         wf_fft = b.absolute(wf_fft) ** 2
+                        wf_fft = self._fold_incoherent_copies(wf_fft)
                     self._array[:, :, kx_i, :] += wf_fft
         else:
             # Standard path: FFT over full time window
@@ -255,12 +272,15 @@ class TACAWData(PySliceSerial, Signal):
                 wf_fft  = b.fftshift(b.fft(sl - wf_mean, axes=1), axes=1)
                 if not self.keep_complex:
                     wf_fft = b.absolute(wf_fft) ** 2
+                    wf_fft = self._fold_incoherent_copies(wf_fft)
                 self._array = wf_fft if self._array is None else self._array + wf_fft
 
         # Persist to cache
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         np.save(cache_freq,  to_numpy(self._frequencies))
-        if not self.use_memmap:
+        if isinstance(self._array, np.memmap):
+            self._array.flush()
+        else:
             np.save(cache_tacaw, to_numpy(self._array))
         # Completion marker written LAST, so its presence guarantees a fully
         # written tacaw.npy that matches this metadata.
@@ -277,7 +297,7 @@ class TACAWData(PySliceSerial, Signal):
 
     def _tacaw_cache_meta(self, layer_index: int, fft_len: int) -> dict:
         """Identity of the cached spectrum: everything that changes its values."""
-        n_probes = int(self._wf_array.shape[0])
+        n_probes = self.n_scan_positions
         nkx = int(self._wf_array.shape[2])
         nky = int(self._wf_array.shape[3])
         return {
@@ -286,6 +306,7 @@ class TACAWData(PySliceSerial, Signal):
             "keep_complex": bool(self.keep_complex),
             "fft_len": int(fft_len),
             "n_chunks": int(self.n_chunks),
+            "n_copies": int(self.n_copies),
             "array_shape": [n_probes, int(fft_len), nkx, nky],
             "wf_dtype": str(getattr(self._wf_array, "dtype", "")),
             "wf_fingerprint": self._array_fingerprint(
@@ -294,6 +315,17 @@ class TACAWData(PySliceSerial, Signal):
             "kx_fingerprint": self._array_fingerprint(self._kxs),
             "ky_fingerprint": self._array_fingerprint(self._kys),
         }
+
+    def _fold_incoherent_copies(self, intensity):
+        """Sum copy-major spectral intensities onto physical scan positions."""
+        if self.n_copies == 1:
+            return intensity
+        b = self._backend
+        folded_shape = (
+            self.n_copies,
+            self.n_scan_positions,
+        ) + tuple(int(s) for s in intensity.shape[1:])
+        return b.sum(b.reshape(intensity, folded_shape), axis=0)
 
     @staticmethod
     def _array_fingerprint(arr) -> str:

--- a/src/pyslice/postprocessing/tacaw_data.py
+++ b/src/pyslice/postprocessing/tacaw_data.py
@@ -288,24 +288,25 @@ class TACAWData(PySliceSerial, Signal):
             "n_chunks": int(self.n_chunks),
             "array_shape": [n_probes, int(fft_len), nkx, nky],
             "wf_dtype": str(getattr(self._wf_array, "dtype", "")),
-            "wf_fingerprint": self._wf_fingerprint(),
+            "wf_fingerprint": self._array_fingerprint(
+                self._wf_array[:, :, :, :, layer_index]),
+            "time_fingerprint": self._array_fingerprint(self._time),
+            "kx_fingerprint": self._array_fingerprint(self._kxs),
+            "ky_fingerprint": self._array_fingerprint(self._kys),
         }
 
-    def _wf_fingerprint(self) -> str:
-        """Content fingerprint of the source wavefunction array.
-
-        Samples up to ~1M elements strided across the whole array (so it detects
-        any global difference, unlike a frame-0-style sample) and hashes them
-        with the shape — enough to tell a different dataset in the same cache_dir
-        apart from this one without a full multi-GB scan.
-        """
-        arr = self._wf_array
+    @staticmethod
+    def _array_fingerprint(arr) -> str:
+        """Hash every value without materialising a potentially huge CPU copy."""
         flat = arr.reshape(-1)
         n = int(flat.shape[0])
-        step = max(1, n // (1 << 20))
-        sample = np.ascontiguousarray(to_numpy(flat[::step]))
-        payload = repr(tuple(int(s) for s in arr.shape)).encode() + sample.tobytes()
-        return hashlib.md5(payload).hexdigest()
+        digest = hashlib.sha256()
+        digest.update(repr(tuple(int(s) for s in arr.shape)).encode())
+        digest.update(str(getattr(arr, "dtype", "")).encode())
+        for start in range(0, n, 1 << 20):
+            block = np.ascontiguousarray(to_numpy(flat[start:start + (1 << 20)]))
+            digest.update(block.tobytes())
+        return digest.hexdigest()
 
     def fft_from_wf_data(self, layer_index: Optional[int] = None):
         """Public alias for backward compatibility."""

--- a/src/pyslice/postprocessing/tacaw_data.py
+++ b/src/pyslice/postprocessing/tacaw_data.py
@@ -3,6 +3,8 @@ Core data structure for TACAW EELS calculations.
 """
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import os
 from pathlib import Path
@@ -172,6 +174,7 @@ class TACAWData(PySliceSerial, Signal):
 
         cache_tacaw = self.cache_dir / "tacaw.npy"
         cache_freq  = self.cache_dir / "tacaw_freq.npy"
+        cache_meta  = self.cache_dir / "tacaw_meta.json"
 
         fft_len = self.chunk_size_time if self.chunk_size_time is not None else len(self._time)
         if self.chunk_size_time is None:
@@ -186,20 +189,36 @@ class TACAWData(PySliceSerial, Signal):
             else:
                 self.n_chunks = len(self._time) // self.chunk_size_time
 
-        if not self.force_rerun and cache_tacaw.exists():
-            cached = np.load(cache_tacaw)
-            _, nt, nx, ny, _ = self._wf_array.shape
-            _, nw, nx2, ny2  = cached.shape
-            if nw == fft_len and nx == nx2 and ny == ny2:
-                self._frequencies = b.asarray(np.load(cache_freq))
-                self._array = b.asarray(cached)
-                return
-
+        # Resolve the layer up front: it — together with keep_complex, the
+        # chunking and the source-wavefunction identity — is part of the cache
+        # identity, so a different layer / dtype / dataset sharing this cache_dir
+        # is never served the wrong cached spectrum (a shape-only check was).
         if layer_index is None:
             layer_index = len(self._layer) - 1
         if not (0 <= layer_index < len(self._layer)):
             raise ValueError(
                 f"layer_index {layer_index} out of range [0, {len(self._layer) - 1}]")
+
+        meta = self._tacaw_cache_meta(layer_index, fft_len)
+        if not self.force_rerun and cache_tacaw.exists() and cache_meta.exists():
+            try:
+                with open(cache_meta) as f:
+                    cached_meta = json.load(f)
+            except (OSError, ValueError):
+                cached_meta = None
+            if cached_meta == meta:
+                cached = np.load(cache_tacaw)
+                if list(cached.shape) == meta["array_shape"]:
+                    self._frequencies = b.asarray(np.load(cache_freq))
+                    self._array = b.asarray(cached)
+                    return
+
+        # A (re)compute invalidates any previous completion marker first, so an
+        # interrupted run (partial tacaw.npy — notably the memmap accumulator)
+        # is never mistaken for a complete cache on the next load.
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        if cache_meta.exists():
+            cache_meta.unlink()
 
         wf_layer = self._wf_array[:, :, :, :, layer_index]  # p,t,kx,ky
 
@@ -243,6 +262,46 @@ class TACAWData(PySliceSerial, Signal):
         np.save(cache_freq,  to_numpy(self._frequencies))
         if not self.use_memmap:
             np.save(cache_tacaw, to_numpy(self._array))
+        # Completion marker written LAST, so its presence guarantees a fully
+        # written tacaw.npy that matches this metadata.
+        with open(cache_meta, "w") as f:
+            json.dump(meta, f)
+
+    # Bump when the TACAW FFT/normalisation changes so stale tacaw.npy caches
+    # are not reused across versions.
+    _TACAW_CACHE_VERSION = 1
+
+    def _tacaw_cache_meta(self, layer_index: int, fft_len: int) -> dict:
+        """Identity of the cached spectrum: everything that changes its values."""
+        n_probes = int(self._wf_array.shape[0])
+        nkx = int(self._wf_array.shape[2])
+        nky = int(self._wf_array.shape[3])
+        return {
+            "cache_version": self._TACAW_CACHE_VERSION,
+            "layer_index": int(layer_index),
+            "keep_complex": bool(self.keep_complex),
+            "fft_len": int(fft_len),
+            "n_chunks": int(self.n_chunks),
+            "array_shape": [n_probes, int(fft_len), nkx, nky],
+            "wf_dtype": str(getattr(self._wf_array, "dtype", "")),
+            "wf_fingerprint": self._wf_fingerprint(),
+        }
+
+    def _wf_fingerprint(self) -> str:
+        """Content fingerprint of the source wavefunction array.
+
+        Samples up to ~1M elements strided across the whole array (so it detects
+        any global difference, unlike a frame-0-style sample) and hashes them
+        with the shape — enough to tell a different dataset in the same cache_dir
+        apart from this one without a full multi-GB scan.
+        """
+        arr = self._wf_array
+        flat = arr.reshape(-1)
+        n = int(flat.shape[0])
+        step = max(1, n // (1 << 20))
+        sample = np.ascontiguousarray(to_numpy(flat[::step]))
+        payload = repr(tuple(int(s) for s in arr.shape)).encode() + sample.tobytes()
+        return hashlib.md5(payload).hexdigest()
 
     def fft_from_wf_data(self, layer_index: Optional[int] = None):
         """Public alias for backward compatibility."""

--- a/src/pyslice/postprocessing/tacaw_data.py
+++ b/src/pyslice/postprocessing/tacaw_data.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 
 from .wf_data import WFData
 from ..data.pyslice_serial import PySliceSerial, Signal, Dimensions, Dimension, Metadata
-from pyslice.backend import Backend, to_numpy
+from pyslice.backend import Backend, to_numpy, source_files_version
 
 logger = logging.getLogger(__name__)
 
@@ -267,9 +267,13 @@ class TACAWData(PySliceSerial, Signal):
         with open(cache_meta, "w") as f:
             json.dump(meta, f)
 
-    # Bump when the TACAW FFT/normalisation changes so stale tacaw.npy caches
-    # are not reused across versions.
-    _TACAW_CACHE_VERSION = 1
+    # Derived automatically from the sources that determine the TACAW spectrum
+    # values, so a change to the FFT/normalisation invalidates stale tacaw.npy
+    # caches without a manual bump. "v1" allows a manual bump if ever needed.
+    _TACAW_CACHE_VERSION = "v1-" + source_files_version([
+        os.path.join(os.path.dirname(__file__), "tacaw_data.py"),
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), "backend.py"),
+    ])
 
     def _tacaw_cache_meta(self, layer_index: int, fft_len: int) -> dict:
         """Identity of the cached spectrum: everything that changes its values."""

--- a/src/pyslice/postprocessing/wf_data.py
+++ b/src/pyslice/postprocessing/wf_data.py
@@ -309,11 +309,16 @@ class WFData(PySliceSerial, Signal):
         dx = self._xs[1]-self._xs[0] ; dy = self._ys[1]-self._ys[0]
         pix_x = int(round(add_x/dx)) ; pix_y = int(round(add_y/dy))
         npt, nt, nx, ny, nl = self._array.shape
-        array = b.ifft2(self._array,axes=(-3,-2)) # npt, nt, nx, ny, nl indices. iFFT x,y
+        # self._array is an fftshifted spectrum, so undo the shift before the
+        # inverse transform and re-apply it after (as applyMask does).  Omitting
+        # these leaves a fractional-bin phase ramp that cancels only for even
+        # grid sizes; for odd nx/ny it smears the padded spectrum (Dirichlet
+        # leakage, up to ~10% amplitude error).
+        array = b.ifft2(b.ifftshift(self._array, axes=(-3,-2)), axes=(-3,-2)) # npt, nt, nx, ny, nl indices. iFFT x,y
         new = b.zeros((npt, nt, nx+pix_x*2, ny+pix_y*2, nl), type_match = self._array)
         i1=pix_x ; i2=pix_x+nx ; j1=pix_y ; j2=pix_y+ny
         new[:,:,i1:i2,j1:j2,:] += array
-        self._array = b.fft2(new,axes=(-3,-2))
+        self._array = b.fftshift(b.fft2(new,axes=(-3,-2)), axes=(-3,-2))
         # xs=[0,1,2,3,4], dx=1, add 3. new should be -3,-2,-1,0,1,2,3,4,5,6,7. from x[0]-N*dx, to x[-1]+N*dx, and length len(xs)+2*N
         self._xs = b.linspace( self._xs[0]-dx*pix_x , self._xs[-1]+dx*pix_x , nx+pix_x*2 )
         self._ys = b.linspace( self._ys[0]-dy*pix_y , self._ys[-1]+dy*pix_y , ny+pix_y*2 )

--- a/src/pyslice/postprocessing/wf_data.py
+++ b/src/pyslice/postprocessing/wf_data.py
@@ -309,6 +309,27 @@ class WFData(PySliceSerial, Signal):
         b = self._backend
         self._xs -= b.mean(self._xs)
         self._ys -= b.mean(self._ys)
+
+    def _row_wavelengths(self):
+        """Return one wavelength for each flattened copy/probe row."""
+        b = self._backend
+        wavelengths = getattr(self.probe, "wavelengths", None)
+        if wavelengths is None:
+            return b.zeros(self._array.shape[0]) + self.probe.wavelength
+
+        wavelengths = b.asarray(wavelengths)
+        n_copies = len(wavelengths)
+        n_positions = len(self.probe_positions)
+        n_rows = self._array.shape[0]
+        if n_copies * n_positions != n_rows:
+            raise ValueError(
+                "wavefunction rows do not match the probe copy and position "
+                f"counts ({n_rows} != {n_copies} * {n_positions})"
+            )
+        return b.reshape(
+            wavelengths[:, None] * b.ones(n_positions)[None, :], (n_rows,)
+        )
+
     def pad_real_space(self,add_x=0,add_y=0):
         b = self._backend
         dx = self._xs[1]-self._xs[0] ; dy = self._ys[1]-self._ys[0]
@@ -331,22 +352,75 @@ class WFData(PySliceSerial, Signal):
         self._kys = b.fftshift(b.fftfreq(ny+pix_y*2, dy))  # k-space in 1/Å
 
 
-    def propagate_through_lens(self,f):
+    def propagate_through_lens(
+        self,
+        f: float,
+        center: Optional[Tuple[float, float]] = None,
+    ):
+        """Apply a thin lens to the specimen exit wave.
+
+        Parameters
+        ----------
+        f
+            Lens focal length in Angstroms.
+        center
+            ``(x, y)`` position of the optical axis in Angstroms. By default,
+            the lens is centred on the sampled simulation grid.
+
+        Stored waves from earlier specimen depths are historical snapshots,
+        not waves that have passed through the downstream lens, so only the
+        final layer is modified.
+        """
+        if f == 0:
+            raise ValueError("f must be nonzero")
+
         b = self._backend
-        array = b.ifft2(self._array[:, :, :, :, -1])
-        xs = b.asarray(self._xs)#-self.probe_positions[-1][0]
-        ys = b.asarray(self._ys)#-self.probe_positions[-1][1]
-        x_grid, y_grid = b.meshgrid(xs,ys, indexing='ij')
-        k = 2*b.pi / self.probe.wavelength
-        L = b.exp(-1j * k / 2 / f * ( x_grid ** 2 + y_grid ** 2 ) )
-        array = L[None,None,:,:] * array
-        self._array[:,:,:,:,-1] = b.fft2(array)
+        xs = b.asarray(self._xs)
+        ys = b.asarray(self._ys)
+        if center is None:
+            center_x, center_y = b.mean(xs), b.mean(ys)
+        else:
+            try:
+                center_x, center_y = center
+            except (TypeError, ValueError):
+                raise ValueError("center must be an (x, y) pair") from None
+
+        x_grid, y_grid = b.meshgrid(
+            xs - center_x, ys - center_y, indexing="ij"
+        )
+        wavelengths = self._row_wavelengths()
+        lens = b.exp(
+            -1j * (2 * b.pi / wavelengths[:, None, None]) / (2 * f)
+            * (x_grid[None, :, :] ** 2 + y_grid[None, :, :] ** 2)
+        )
+
+        # WFData stores fftshifted reciprocal-space waves. Undo that shift for
+        # the real-space lens operation, then restore the storage convention.
+        exit_wave = b.ifft2(
+            b.ifftshift(self._array[:, :, :, :, -1], axes=(-2, -1)),
+            axes=(-2, -1),
+        )
+        exit_wave *= lens[:, None, :, :]
+        self._array[:, :, :, :, -1] = b.fftshift(
+            b.fft2(exit_wave, axes=(-2, -1)), axes=(-2, -1)
+        )
 
     def propagate_free_space(self, dz: float):
+        """Propagate the specimen exit wave through free space by ``dz`` Angstroms.
+
+        Earlier stored layers describe waves inside the specimen and are left
+        unchanged; only the final exit wave enters the downstream free space.
+        """
         b = self._backend
         kx_grid, ky_grid = b.meshgrid(self._kxs, self._kys, indexing='ij')
-        P = b.exp(-1j * b.pi * self.probe.wavelength * dz * (kx_grid ** 2 + ky_grid ** 2))
-        self._array = P[None, None, :, :, None] * self._array
+        wavelengths = self._row_wavelengths()
+        P = b.exp(
+            -1j * b.pi * wavelengths[:, None, None] * dz
+            * (kx_grid[None, :, :] ** 2 + ky_grid[None, :, :] ** 2)
+        )
+        self._array[:, :, :, :, -1] = (
+            P[:, None, :, :] * self._array[:, :, :, :, -1]
+        )
 
     def addSpatialDecoherence(self, sigma_dz: float, N: int):
         b = self._backend

--- a/src/pyslice/postprocessing/wf_data.py
+++ b/src/pyslice/postprocessing/wf_data.py
@@ -156,9 +156,14 @@ class WFData(PySliceSerial, Signal):
         b = self._backend
         npt, nt, nx, ny, nl = self._array.shape
         if self.probability is None:
-            self.probability = self._array
-            ary = self._array / b.sum(b.absolute(self._array))
-            ary = b.absolute(b.reshape(ary, (npt * nt * nx * ny * nl,)))
+            # Detection probability is proportional to intensity |psi|^2, not
+            # amplitude |psi|. Sampling from |psi| (as before) over-counts weak
+            # features: a pixel 100x weaker in intensity was only 10x less likely
+            # to be hit. Build the sampling CDF from the normalized intensity.
+            intensity = b.reshape(b.absolute(self._array) ** 2,
+                                  (npt * nt * nx * ny * nl,))
+            ary = intensity / b.sum(intensity)
+            self.probability = ary
             self.buckets = b.zeros(len(ary) + 1, type_match=ary)
             self.buckets[1:] = b.cumsum(ary)
         detector_hits = b.asarray(b.randfloats(N))

--- a/tests/25_review_regressions.py
+++ b/tests/25_review_regressions.py
@@ -11,6 +11,7 @@ from pyslice.multislice.calculators import MultisliceCalculator
 from pyslice.multislice.multislice import PrismProbe, Probe, Propagate, wavelength
 from pyslice.multislice.potentials import Potential
 from pyslice.multislice.trajectory import Trajectory
+from pyslice.io.loader import Loader
 from pyslice.postprocessing.haadf_data import HAADFData
 from pyslice.postprocessing.tacaw_data import TACAWData
 from pyslice.postprocessing.wf_data import WFData
@@ -594,6 +595,37 @@ def test_slice_axis_other_than_z_is_rejected(tmp_path, monkeypatch):
                   positions=np.array([[1.0, 1.0, 1.0]]),
                   atom_types=np.array([14]), backend=NumpyBackend(),
                   kind="gauss", slice_axis=0)
+
+
+def _loader(tmp_path, **kwargs):
+    dump = tmp_path / "dummy.lammpstrj"
+    dump.write_text("")  # only needs to exist; we call the resolver directly
+    return Loader(filename=str(dump), **kwargs)
+
+
+def test_ovito_type_ids_are_never_used_as_atomic_numbers(tmp_path):
+    # LAMMPS type IDs must not be treated as Z. Element identity comes from an
+    # explicit mapping or the file's embedded element names; otherwise abort.
+    ids = np.array([1, 1, 2])
+
+    # embedded element names present -> mapped to element symbols
+    resolved = _loader(tmp_path)._resolve_ovito_types(ids, {1: "Si", 2: "O"})
+    assert list(resolved) == ["Si", "Si", "O"]
+
+    # no names and no mapping -> abort asking for an exact mapping
+    with pytest.raises(ValueError, match="atom_mapping"):
+        _loader(tmp_path)._resolve_ovito_types(ids, {})
+    # a numeric/junk type name is NOT accepted as an element
+    with pytest.raises(ValueError, match="atom_mapping"):
+        _loader(tmp_path)._resolve_ovito_types(np.array([1]), {1: "1"})
+
+    # explicit mapping wins and yields atomic numbers
+    resolved = _loader(tmp_path, atom_mapping={1: "Si", 2: "O"})._resolve_ovito_types(ids, {})
+    assert list(resolved) == [14, 14, 8]
+
+    # explicit mapping must be exact: a missing type aborts
+    with pytest.raises(ValueError, match="missing entries"):
+        _loader(tmp_path, atom_mapping={1: "Si"})._resolve_ovito_types(ids, {2: "O"})
 
 
 def test_pyproject_sdist_ships_package_source():

--- a/tests/25_review_regressions.py
+++ b/tests/25_review_regressions.py
@@ -549,6 +549,38 @@ def test_min_dk_calculator_run_completes(tmp_path, monkeypatch):
     assert np.max(np.abs(arr)) > 0
 
 
+@pytest.mark.parametrize("n", [32, 33, 63])
+def test_pad_real_space_preserves_field_for_odd_and_even_grids(tmp_path, n):
+    # self._array is an fftshifted spectrum; pad_real_space must undo/redo the
+    # shift around its FFT round trip.  Without that it is exact only for even
+    # grids and smears odd-grid spectra by several percent.
+    pad = 5
+    xs = np.arange(n, dtype=float)
+    xg, yg = np.meshgrid(xs, xs, indexing="ij")
+    psi = (np.exp(-((xg - n * 0.4) ** 2 + (yg - n * 0.6) ** 2) / (0.8 * n))
+           * np.exp(1j * 0.3 * xg))  # asymmetric -> sensitive to a shift error
+    spectrum = np.fft.fftshift(np.fft.fft2(psi))
+
+    probe = SimpleNamespace(
+        eV=1e5, wavelength=0.037, mrad=30.0,
+        _array=NumpyBackend().asarray(np.zeros((1, 1, 2, 2), dtype=np.complex128)))
+    wf = WFData(
+        probe_positions=[(0.0, 0.0)], probe_xs=[0.0], probe_ys=[0.0],
+        time=np.zeros(1),
+        kxs=np.fft.fftshift(np.fft.fftfreq(n)), kys=np.fft.fftshift(np.fft.fftfreq(n)),
+        xs=xs.copy(), ys=xs.copy(), layer=np.array([0]),
+        array=spectrum[None, None, :, :, None].astype(np.complex128),
+        probe=probe, backend=NumpyBackend(), cache_dir=tmp_path,
+    )
+    wf.pad_real_space(add_x=pad, add_y=pad)
+
+    recovered = np.fft.ifft2(np.fft.ifftshift(to_numpy(wf._array)[0, 0, :, :, 0]))
+    reference = np.zeros((n + 2 * pad, n + 2 * pad), dtype=complex)
+    reference[pad:pad + n, pad:pad + n] = psi
+    rel_err = np.max(np.abs(recovered - reference)) / np.max(np.abs(psi))
+    assert rel_err < 1e-10
+
+
 def _make_wf_data(tmp_path, n_time, backend=None):
     backend = NumpyBackend() if backend is None else backend
     probe = SimpleNamespace(

--- a/tests/25_review_regressions.py
+++ b/tests/25_review_regressions.py
@@ -672,3 +672,60 @@ def _make_wf_data(tmp_path, n_time, backend=None):
         backend=backend,
         cache_dir=tmp_path,
     )
+
+
+def test_wavefunction_cache_key_uses_full_trajectory(tmp_path, monkeypatch):
+    # The key hashes the whole trajectory, so runs differing only in a later
+    # frame or in y/z (e.g. a temperature sweep from the same initial structure)
+    # no longer collide on the frame-0-x fingerprint.
+    monkeypatch.chdir(tmp_path)
+    base = (np.random.RandomState(0).rand(5, 2, 3) * 3).astype(np.float32)
+
+    def key(pos):
+        traj = Trajectory(
+            atom_types=np.array([14, 14]), positions=pos.astype(np.float32),
+            velocities=np.zeros_like(pos, dtype=np.float32),
+            box_matrix=np.diag([8.0, 8.0, 3.0]), timestep=0.1)
+        calc = MultisliceCalculator(force_cpu=True)
+        calc.setup(traj, aperture=30, voltage_eV=100e3, sampling=0.25,
+                   slice_thickness=1.0, probe_positions=[(4.0, 4.0)],
+                   cache_wavefunctions=False)
+        return calc.cache_key
+
+    k = key(base.copy())
+    assert key(base.copy()) == k                       # identical -> shared cache
+    later = base.copy(); later[3, 0, 0] += 0.5
+    assert key(later) != k                             # differs only in frame 3
+    ycomp = base.copy(); ycomp[0, 0, 1] += 0.5
+    assert key(ycomp) != k                             # differs only in frame-0 y
+
+
+def _make_layered_wf(cache_dir, n_layers=2, seed=0):
+    nt = 16
+    t = np.arange(nt) * 0.1
+    arr = np.zeros((1, nt, 2, 2, n_layers), dtype=np.complex128)
+    for layer in range(n_layers):
+        freq = (layer + 1) * 1.0 + seed * 0.3  # distinct per layer/dataset
+        arr[0, :, :, :, layer] = np.cos(2 * np.pi * freq * t)[:, None, None]
+    probe = SimpleNamespace(
+        eV=1e5, wavelength=0.037, mrad=30.0,
+        _array=NumpyBackend().asarray(np.zeros((1, 1, 2, 2), dtype=np.complex128)))
+    return WFData(
+        probe_positions=[(0.0, 0.0)], probe_xs=[0.0], probe_ys=[0.0], time=t,
+        kxs=np.arange(2.0), kys=np.arange(2.0), xs=np.arange(2.0), ys=np.arange(2.0),
+        layer=np.arange(n_layers), array=arr, probe=probe,
+        backend=NumpyBackend(), cache_dir=cache_dir)
+
+
+def test_tacaw_cache_distinguishes_layer_dtype_and_dataset(tmp_path):
+    # The tacaw.npy cache used a shape-only check, so a different layer / dtype /
+    # dataset in the same cache_dir was silently served the first spectrum.
+    wf = _make_layered_wf(tmp_path, seed=1)
+    s0 = to_numpy(TACAWData(wf, layer_index=0)._array).copy()
+    s1 = to_numpy(TACAWData(wf, layer_index=1)._array)   # same dir, other layer
+    assert not np.allclose(s0, s1)
+    assert np.allclose(s0, to_numpy(TACAWData(wf, layer_index=0)._array))  # hit is stable
+    sc = to_numpy(TACAWData(wf, layer_index=0, keep_complex=True)._array)
+    assert sc.dtype.kind == "c"                          # complex, not cached real intensity
+    wf2 = _make_layered_wf(tmp_path, seed=2)             # different data, same cache_dir
+    assert not np.allclose(s0, to_numpy(TACAWData(wf2, layer_index=0)._array))

--- a/tests/25_review_regressions.py
+++ b/tests/25_review_regressions.py
@@ -853,3 +853,50 @@ def test_multiframe_cif_loads_all_frames_and_index_selects(tmp_path):
     np.testing.assert_allclose(strided.positions[:, 0, 0], [0, 2, 4])
     assert strided.timestep == 1.0                    # step rescales timestep
     assert load(1).n_frames == 1
+
+
+def _adf_run(tmp_path, monkeypatch, **setup_kw):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(tmp_path)
+    s = np.array([[[4., 4., 1.0], [3., 5., 2.5]]], dtype=np.float32)
+    traj = Trajectory(atom_types=np.array([14, 14]), positions=s,
+                      velocities=np.zeros_like(s), box_matrix=np.diag([8., 8., 4.]),
+                      timestep=0.1)
+    calc = MultisliceCalculator(force_cpu=True)
+    calc.setup(traj, aperture=30, voltage_eV=100e3, sampling=0.25, slice_thickness=1.0,
+               probe_xs=[2., 4., 6.], probe_ys=[2., 4., 6.], ADF=(45, 150),
+               cache_wavefunctions=False, **setup_kw)
+    return calc.run(force_rerun=True)
+
+
+def test_adf_depth_resolved_stack_not_layer_sum(tmp_path, monkeypatch):
+    # Default: a single exit-wave ADF, kept 2D for back-compat.
+    _, adf = _adf_run(tmp_path, monkeypatch)
+    assert to_numpy(adf.array).shape == (3, 3)
+    # return_layers='all': one ADF per thickness (a stack), NOT a sum over layers.
+    _, adf_all = _adf_run(tmp_path / "all", monkeypatch, return_layers="all")
+    stack = to_numpy(adf_all.array)
+    assert stack.ndim == 3 and stack.shape[1:] == (3, 3)
+    assert stack.shape[0] == len(adf_all.thicknesses)
+    np.testing.assert_allclose(stack[-1], to_numpy(adf.array), atol=1e-6)  # exit == default
+    assert not np.allclose(stack[0], stack[-1])          # genuinely per-thickness
+    assert not np.allclose(stack[-1], stack.sum(0))      # not the old layer-sum
+
+
+def test_adf_sums_decoherence_copies(tmp_path, monkeypatch):
+    def total(deco):
+        s = np.array([[[4., 4., 1.0], [3., 5., 2.5]]], dtype=np.float32)
+        traj = Trajectory(atom_types=np.array([14, 14]), positions=s,
+                          velocities=np.zeros_like(s), box_matrix=np.diag([8., 8., 4.]),
+                          timestep=0.1)
+        monkeypatch.chdir(tmp_path)
+        calc = MultisliceCalculator(force_cpu=True)
+        calc.setup(traj, aperture=30, voltage_eV=100e3, sampling=0.25, slice_thickness=1.0,
+                   probe_xs=[2., 4., 6.], probe_ys=[2., 4., 6.], ADF=(45, 150),
+                   cache_wavefunctions=False, return_layers=None)
+        if deco:
+            calc.base_probe.addTemporalDecoherence(2.0, 3)  # nc = 3
+        return float(np.sum(np.abs(to_numpy(calc.run(force_rerun=True)[1].array))))
+    # summed copies -> ~1; the old zip() dropped all but the first (-2 sigma tail) -> ~3e-4
+    ratio = total(True) / total(False)
+    assert 0.9 < ratio < 1.1, ratio

--- a/tests/25_review_regressions.py
+++ b/tests/25_review_regressions.py
@@ -729,3 +729,21 @@ def test_tacaw_cache_distinguishes_layer_dtype_and_dataset(tmp_path):
     assert sc.dtype.kind == "c"                          # complex, not cached real intensity
     wf2 = _make_layered_wf(tmp_path, seed=2)             # different data, same cache_dir
     assert not np.allclose(s0, to_numpy(TACAWData(wf2, layer_index=0)._array))
+
+
+def test_cache_versions_are_derived_from_source(tmp_path):
+    from pyslice.backend import source_files_version
+    # the helper is content-sensitive and tolerates missing files
+    f = tmp_path / "a.py"
+    f.write_bytes(b"x = 1\n")
+    v1 = source_files_version([f])
+    f.write_bytes(b"x = 2\n")
+    assert source_files_version([f]) != v1
+    source_files_version([tmp_path / "does_not_exist.py"])  # must not raise
+    # both cache tags embed a source hash (not a bare manual constant) and are
+    # independent of each other
+    wf_v = MultisliceCalculator._CACHE_VERSION
+    tacaw_v = TACAWData._TACAW_CACHE_VERSION
+    assert wf_v.startswith("v3-") and len(wf_v) > len("v3-")
+    assert tacaw_v.startswith("v1-") and len(tacaw_v) > len("v1-")
+    assert wf_v != tacaw_v

--- a/tests/25_review_regressions.py
+++ b/tests/25_review_regressions.py
@@ -399,6 +399,86 @@ def test_static_trajectory_offcentre_probe_gives_frame_invariant_exit_wave(tmp_p
         np.testing.assert_allclose(arr[:, t], reference, atol=1e-10, rtol=0)
 
 
+def test_explicit_probe_position_list_is_simulated_verbatim(tmp_path, monkeypatch):
+    # A non-grid probe_positions list (e.g. two atomic columns on a diagonal)
+    # used to be silently rebuilt into the outer-product grid of its unique x/y
+    # values.  That both changed the physics and desynced n_probes from the
+    # number of probes actually simulated -> a shape-mismatch crash as soon as
+    # wavefunctions were returned.
+    monkeypatch.chdir(tmp_path)
+    n_frames = 2
+    static = np.tile(np.array([[[3.1, 4.7, 1.5]]], dtype=float), (n_frames, 1, 1))
+    traj = Trajectory(
+        atom_types=np.array([14]),
+        positions=static,
+        velocities=np.zeros_like(static),
+        box_matrix=np.diag([8.0, 8.0, 3.0]),
+        timestep=0.1,
+    )
+    requested = [(2.0, 2.0), (6.0, 6.0)]  # diagonal -> not a full 2x2 grid
+    calc = MultisliceCalculator(force_cpu=True)
+    calc.setup(
+        traj,
+        aperture=30,
+        voltage_eV=60e3,
+        sampling=0.25,
+        slice_thickness=1.0,
+        probe_positions=requested,
+        cache_wavefunctions=False,
+    )
+    wave = calc.run(force_rerun=True)  # must not raise
+
+    # exactly the requested probes are simulated (not expanded to a 4-point grid)
+    np.testing.assert_allclose(
+        np.asarray(calc.base_probe.probe_positions, dtype=float), requested)
+    assert len(calc.probe_positions) == len(calc.base_probe.probe_positions)
+    assert to_numpy(wave.array).shape[0] == len(requested)
+
+
+def _adf_image_for(probe_kwargs, tmp_path, monkeypatch):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(tmp_path)
+    static = np.tile(
+        np.array([[[3.1, 4.7, 1.5], [5.5, 2.2, 1.5]]], dtype=float), (2, 1, 1))
+    traj = Trajectory(
+        atom_types=np.array([14, 14]),
+        positions=static,
+        velocities=np.zeros_like(static),
+        box_matrix=np.diag([8.0, 8.0, 3.0]),
+        timestep=0.1,
+    )
+    calc = MultisliceCalculator(force_cpu=True)
+    calc.setup(traj, aperture=30, voltage_eV=60e3, sampling=0.25,
+               slice_thickness=1.0, ADF=(45, 150), cache_wavefunctions=False,
+               **probe_kwargs)
+    wf, _ = calc.run(force_rerun=True)
+    return to_numpy(HAADFData(wf).calculateADF())
+
+
+def test_full_grid_probe_list_canonicalised_so_image_maps_correctly(tmp_path, monkeypatch):
+    # A full grid handed in as an explicit list in a non-meshgrid order must
+    # produce the SAME 2D image as the probe_xs/probe_ys path: WFData.reshaped()
+    # assumes meshgrid order, so setup() canonicalises full grids to it.
+    reference = _adf_image_for(dict(probe_xs=[2.0, 6.0], probe_ys=[2.0, 6.0]),
+                               tmp_path / "ref", monkeypatch)
+    scrambled = _adf_image_for(dict(probe_positions=[(6., 6.), (2., 2.), (6., 2.), (2., 6.)]),
+                               tmp_path / "scr", monkeypatch)
+    nested = _adf_image_for(dict(probe_positions=[(2., 2.), (2., 6.), (6., 2.), (6., 6.)]),
+                            tmp_path / "nest", monkeypatch)
+    np.testing.assert_allclose(scrambled, reference, atol=1e-10, rtol=0)
+    np.testing.assert_allclose(nested, reference, atol=1e-10, rtol=0)
+
+
+def test_malformed_probe_positions_raise_clear_error(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    traj = _make_tiny_trajectory()
+    for bad in [(4.0, 4.0), [], [(2, 2, 4), (6, 6, 4)]]:
+        calc = MultisliceCalculator(force_cpu=True)
+        with pytest.raises(ValueError, match="probe_positions must be"):
+            calc.setup(traj, aperture=5, voltage_eV=60e3, sampling=1.0,
+                       slice_thickness=1.0, probe_positions=bad)
+
+
 def _make_wf_data(tmp_path, n_time, backend=None):
     backend = NumpyBackend() if backend is None else backend
     probe = SimpleNamespace(

--- a/tests/25_review_regressions.py
+++ b/tests/25_review_regressions.py
@@ -700,6 +700,21 @@ def test_wavefunction_cache_key_uses_full_trajectory(tmp_path, monkeypatch):
     assert key(ycomp) != k                             # differs only in frame-0 y
 
 
+def test_wavefunction_cache_key_partitions_skip_vacuum(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    traj = _make_tiny_trajectory()
+
+    def key(skip_vacuum):
+        calc = MultisliceCalculator(force_cpu=True)
+        calc.setup(
+            traj, aperture=30, voltage_eV=60e3, sampling=0.25,
+            slice_thickness=1.0, probe_xs=[1.0, 2.0], probe_ys=[1.0],
+            min_dk=0.25, skip_vacuum=skip_vacuum)
+        return calc.cache_key
+
+    assert key(False) != key(True)
+
+
 def _make_layered_wf(cache_dir, n_layers=2, seed=0):
     nt = 16
     t = np.arange(nt) * 0.1
@@ -729,6 +744,24 @@ def test_tacaw_cache_distinguishes_layer_dtype_and_dataset(tmp_path):
     assert sc.dtype.kind == "c"                          # complex, not cached real intensity
     wf2 = _make_layered_wf(tmp_path, seed=2)             # different data, same cache_dir
     assert not np.allclose(s0, to_numpy(TACAWData(wf2, layer_index=0)._array))
+
+
+def test_tacaw_cache_distinguishes_timestep_and_hashes_every_value(tmp_path):
+    wf = _make_layered_wf(tmp_path, seed=1)
+    first = TACAWData(wf, layer_index=0)
+    frequencies = first.frequencies.copy()
+
+    # The FFT values alone do not identify their frequency axis: identical
+    # samples at a different timestep must not inherit the old frequencies.
+    wf._time = wf._time * 2
+    second = TACAWData(wf, layer_index=0)
+    np.testing.assert_allclose(second.frequencies, frequencies / 2)
+
+    # A single changed value must never hide between stride-sampled elements.
+    large = np.zeros((1 << 20) + 3, dtype=np.complex128)
+    fingerprint = TACAWData._array_fingerprint(large)
+    large[(1 << 19) + 1] = 1
+    assert TACAWData._array_fingerprint(large) != fingerprint
 
 
 def test_cache_versions_are_derived_from_source(tmp_path):
@@ -764,6 +797,18 @@ def test_slice_positions_translates_atoms_into_new_box():
     xs = sliced.positions[0, :, 0]
     assert np.all((xs >= 0.0) & (xs <= 3.0))          # atoms 6.0, 7.5 -> 1.0, 2.5
     np.testing.assert_allclose(sorted(xs), [1.0, 2.5])
+
+
+def test_slice_positions_applies_crop_when_every_atom_survives():
+    pos = np.array([[[6.0, 1.0, 1.0], [7.5, 2.0, 3.0]]], dtype=float)
+    traj = Trajectory(
+        atom_types=np.array([14, 14]), positions=pos,
+        velocities=np.zeros_like(pos), box_matrix=np.diag([10.0, 10.0, 10.0]),
+        timestep=0.1)
+    sliced = traj.slice_positions(x_range=(5.0, 8.0))
+    assert sliced is not traj
+    assert sliced.box_matrix[0, 0] == 3.0
+    np.testing.assert_allclose(sliced.positions[0, :, 0], [1.0, 2.5])
 
 
 def test_ovito_cell_matrix_transposed_to_row_convention():
@@ -855,6 +900,42 @@ def test_multiframe_cif_loads_all_frames_and_index_selects(tmp_path):
     assert load(1).n_frames == 1
 
 
+def test_loader_cache_tracks_source_parser_and_mapping_inputs(tmp_path, monkeypatch):
+    source = tmp_path / "trajectory.fake"
+    source.write_text("1")
+    calls = []
+
+    def fake_parse(self):
+        calls.append((source.read_text(), self.atomic_numbers))
+        x = float(source.read_text())
+        positions = np.array([[[x, 0.0, 0.0]]], dtype=np.float32)
+        atom_type = 14 if self.atomic_numbers is None else self.atomic_numbers[1]
+        return Trajectory(
+            atom_types=np.array([atom_type]), positions=positions,
+            velocities=np.zeros_like(positions), box_matrix=np.eye(3) * 10,
+            timestep=self.timestep)
+
+    monkeypatch.setattr(Loader, "_load_via_ovito", fake_parse)
+    assert Loader(str(source)).load().positions[0, 0, 0] == 1
+    assert Loader(str(source)).load().positions[0, 0, 0] == 1
+    assert len(calls) == 1                              # unchanged cache hit
+
+    source.write_text("2")
+    assert Loader(str(source)).load().positions[0, 0, 0] == 2
+    assert len(calls) == 2                              # source invalidated
+
+    mapped = Loader(str(source), atom_mapping={1: "C"}).load()
+    assert mapped.atom_types.tolist() == [6]
+    assert len(calls) == 3                              # mapping invalidated
+    assert Loader(str(source), atom_mapping={1: 6}).load().atom_types.tolist() == [6]
+    assert len(calls) == 3                              # canonical mapping cache hit
+
+    # Legacy existence-only caches have no provenance and must be reparsed.
+    Loader(str(source))._get_cache_files()["metadata"].unlink()
+    Loader(str(source)).load()
+    assert len(calls) == 4
+
+
 def _adf_run(tmp_path, monkeypatch, **setup_kw):
     tmp_path.mkdir(parents=True, exist_ok=True)
     monkeypatch.chdir(tmp_path)
@@ -883,8 +964,38 @@ def test_adf_depth_resolved_stack_not_layer_sum(tmp_path, monkeypatch):
     assert not np.allclose(stack[-1], stack.sum(0))      # not the old layer-sum
 
 
+def test_adf_depth_stack_exposes_a_layer_dimension(monkeypatch):
+    import pyslice.postprocessing.haadf_data as haadf_module
+
+    class FakeDimension:
+        def __init__(self, **kwargs):
+            self.name = kwargs['name']
+            self.values = np.asarray(kwargs['values'])
+            self.units = kwargs.get('units')
+
+    class FakeDimensions:
+        def __init__(self, dimensions, nav_dimensions, sig_dimensions):
+            self.dimensions = dimensions
+            self.nav_dimensions = nav_dimensions
+            self.sig_dimensions = sig_dimensions
+
+    class FakeMetadata:
+        def __init__(self, values):
+            self.Simulation = SimpleNamespace(**values['Simulation'])
+
+    monkeypatch.setattr(haadf_module, 'Dimension', FakeDimension)
+    monkeypatch.setattr(haadf_module, 'Dimensions', FakeDimensions)
+    monkeypatch.setattr(haadf_module, 'Metadata', FakeMetadata)
+
+    wf = _make_layered_wf(None, n_layers=2)
+    adf = haadf_module.HAADFData(wf)
+    adf.calculateADF(inner_mrad=0, outer_mrad=1e6)
+    assert [d.name for d in adf.dimensions.dimensions] == ['layer', 'x', 'y']
+    np.testing.assert_array_equal(adf.dimensions.dimensions[0].values, [0, 1])
+
+
 def test_adf_sums_decoherence_copies(tmp_path, monkeypatch):
-    def total(deco):
+    def total(n_copies):
         s = np.array([[[4., 4., 1.0], [3., 5., 2.5]]], dtype=np.float32)
         traj = Trajectory(atom_types=np.array([14, 14]), positions=s,
                           velocities=np.zeros_like(s), box_matrix=np.diag([8., 8., 4.]),
@@ -894,9 +1005,76 @@ def test_adf_sums_decoherence_copies(tmp_path, monkeypatch):
         calc.setup(traj, aperture=30, voltage_eV=100e3, sampling=0.25, slice_thickness=1.0,
                    probe_xs=[2., 4., 6.], probe_ys=[2., 4., 6.], ADF=(45, 150),
                    cache_wavefunctions=False, return_layers=None)
-        if deco:
-            calc.base_probe.addTemporalDecoherence(2.0, 3)  # nc = 3
+        if n_copies:
+            calc.base_probe.addTemporalDecoherence(2.0, n_copies)
         return float(np.sum(np.abs(to_numpy(calc.run(force_rerun=True)[1].array))))
-    # summed copies -> ~1; the old zip() dropped all but the first (-2 sigma tail) -> ~3e-4
-    ratio = total(True) / total(False)
-    assert 0.9 < ratio < 1.1, ratio
+    baseline = total(None)
+    # Correct quadrature is independent of the number of samples. N=3 happened
+    # to pass before because its central sample dominated; N=5/7 exposed the
+    # missing normalisation as a dose increase.
+    for n_copies in (3, 5, 7):
+        ratio = total(n_copies) / baseline
+        assert 0.9 < ratio < 1.1, (n_copies, ratio)
+
+
+def test_decoherence_default_wavefunction_storage_keeps_every_copy(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    s = np.array([[[4., 4., 1.0], [3., 5., 2.5]]], dtype=np.float32)
+    traj = Trajectory(
+        atom_types=np.array([14, 14]), positions=s, velocities=np.zeros_like(s),
+        box_matrix=np.diag([8., 8., 4.]), timestep=0.1)
+    calc = MultisliceCalculator(force_cpu=True)
+    calc.setup(
+        traj, aperture=30, voltage_eV=100e3, sampling=0.25,
+        slice_thickness=1.0, probe_xs=[2., 4., 6.], probe_ys=[2., 4., 6.],
+        ADF=(45, 150), cache_wavefunctions=True)  # default return_layers=-1
+    calc.base_probe.addTemporalDecoherence(2.0, 3)
+    wf, adf = calc.run(force_rerun=True)
+    assert wf.array.shape[0] == 3 * 9
+    assert adf.array.shape == (3, 3)
+    assert np.isfinite(to_numpy(wf.array)).all()
+
+    # A second calculator must fold all cached copies into the same detector
+    # result; the old cache path indexed only the first copy.
+    expected = to_numpy(adf.array).copy()
+    cached_calc = MultisliceCalculator(force_cpu=True)
+    cached_calc.setup(
+        traj, aperture=30, voltage_eV=100e3, sampling=0.25,
+        slice_thickness=1.0, probe_xs=[2., 4., 6.], probe_ys=[2., 4., 6.],
+        ADF=(45, 150), cache_wavefunctions=True)
+    cached_calc.base_probe.addTemporalDecoherence(2.0, 3)
+    cached_wf, cached_adf = cached_calc.run()
+    assert cached_wf.array.shape[0] == 3 * 9
+    np.testing.assert_allclose(to_numpy(cached_adf.array), expected, rtol=1e-7)
+
+
+def test_decoherence_weights_preserve_total_probe_dose():
+    baseline_probe = _make_deferred_probe((4.0, 4.0))
+    baseline_probe.applyShifts()
+    baseline = np.sum(np.abs(to_numpy(baseline_probe._array)) ** 2)
+
+    for n_copies in (3, 5, 7):
+        probe = _make_deferred_probe((4.0, 4.0))
+        probe.addTemporalDecoherence(2.0, n_copies)
+        total = np.sum(np.abs(to_numpy(probe._array)) ** 2)
+        np.testing.assert_allclose(total, baseline, rtol=1e-7)
+
+    probe = _make_deferred_probe((4.0, 4.0))
+    probe.addSpatialDecoherence(50.0, 7)
+    total = np.sum(np.abs(to_numpy(probe._array)) ** 2)
+    np.testing.assert_allclose(total, baseline, rtol=1e-7)
+
+    with pytest.raises(ValueError, match="positive"):
+        probe.addTemporalDecoherence(0, 3)
+    with pytest.raises(ValueError, match="positive integer"):
+        probe.addSpatialDecoherence(1, 0)
+
+    # One quadrature point denotes the distribution centre, not its -2 sigma
+    # endpoint (numpy.linspace(start, stop, 1) returns start).
+    temporal_one = _make_deferred_probe((4.0, 4.0))
+    temporal_one.addTemporalDecoherence(2.0, 1)
+    np.testing.assert_allclose(to_numpy(temporal_one.eVs), [temporal_one.eV])
+    spatial_one = _make_deferred_probe((4.0, 4.0))
+    reference = to_numpy(spatial_one._array).copy()
+    spatial_one.addSpatialDecoherence(50.0, 1)
+    np.testing.assert_allclose(to_numpy(spatial_one._array), reference, atol=1e-12)

--- a/tests/25_review_regressions.py
+++ b/tests/25_review_regressions.py
@@ -581,6 +581,21 @@ def test_pad_real_space_preserves_field_for_odd_and_even_grids(tmp_path, n):
     assert rel_err < 1e-10
 
 
+def test_pyproject_sdist_ships_package_source():
+    # The sdist must declare the package source; otherwise hatchling shipped a
+    # data-only sdist and every sdist-based install produced an empty package.
+    import tomllib
+    import pathlib
+    root = pathlib.Path(__file__).resolve().parents[1]
+    cfg = tomllib.loads((root / "pyproject.toml").read_text())
+    build = cfg["tool"]["hatch"]["build"]
+    sdist_include = build["targets"]["sdist"]["include"]
+    assert any("src/pyslice" in p for p in sdist_include), sdist_include
+    # no lingering global data-only include and no dead setuptools placeholder
+    assert "include" not in build
+    assert "setuptools" not in cfg["tool"]
+
+
 def _make_wf_data(tmp_path, n_time, backend=None):
     backend = NumpyBackend() if backend is None else backend
     probe = SimpleNamespace(

--- a/tests/25_review_regressions.py
+++ b/tests/25_review_regressions.py
@@ -793,3 +793,22 @@ def test_npt_barostat_params_have_physical_units():
     assert externalstress < 1e-6                       # ~6.3e-7, not ~1
     # pfactor = ptime^2 * B (was 75*fs**2, ~1e5x too small)
     np.testing.assert_allclose(pfactor, (75 * units.fs) ** 2 * (100.0 * units.GPa))
+
+
+def test_counts_samples_from_intensity_not_amplitude():
+    # Shot-noise counting must draw from |psi|^2 (intensity), not |psi|. Two
+    # pixels with amplitudes 1 and 3 (intensities 1 and 9) must be hit ~9:1.
+    from types import SimpleNamespace
+    arr = np.array([1.0, 3.0], dtype=np.complex128).reshape(1, 1, 1, 2, 1)
+    probe = SimpleNamespace(
+        eV=1e5, wavelength=0.037, mrad=30.0,
+        _array=NumpyBackend().asarray(np.zeros((1, 1, 2, 2), dtype=np.complex128)))
+    wf = WFData(
+        probe_positions=[(0.0, 0.0)], probe_xs=[0.0], probe_ys=[0.0],
+        time=np.zeros(1), kxs=np.arange(1.0), kys=np.arange(2.0),
+        xs=np.arange(1.0), ys=np.arange(2.0), layer=np.array([0]),
+        array=arr, probe=probe, backend=NumpyBackend(), cache_dir=".")
+    wf.counts(2_000_000)
+    hits = to_numpy(wf._array).ravel()
+    ratio = hits[1] / hits[0]
+    assert 8.3 < ratio < 9.7, ratio          # intensity 9:1, not amplitude 3:1

--- a/tests/25_review_regressions.py
+++ b/tests/25_review_regressions.py
@@ -243,6 +243,57 @@ def test_prism_loop_probes_smoke_preserves_backend(tmp_path, monkeypatch):
     assert to_numpy(wave.array).shape[0] == 2
 
 
+@pytest.mark.parametrize("use_memmap", [False, True])
+def test_prism_adf_reconstructs_default_and_multilayer_outputs(
+    tmp_path, monkeypatch, use_memmap
+):
+    def run(subdir, return_layers):
+        work = tmp_path / subdir
+        work.mkdir()
+        monkeypatch.chdir(work)
+        calc = MultisliceCalculator(force_cpu=True)
+        calc.setup(
+            _make_tiny_trajectory(), aperture=30, voltage_eV=60e3,
+            sampling=1.0, slice_thickness=1.0,
+            probe_xs=[1.0, 2.0], probe_ys=[1.0], prism=2,
+            loop_probes=1, cache_wavefunctions=False, ADF=(5, 40),
+            return_layers=return_layers, use_memmap=use_memmap)
+        return calc, calc.run(force_rerun=True)
+
+    _, (wave, adf) = run("exit", -1)
+    assert to_numpy(wave.array).shape == (2, 1, 5, 5, 1)
+    assert np.any(np.abs(to_numpy(wave.array)) > 0)
+    assert to_numpy(adf.array).shape == (2, 1)
+
+    calc, (wave_all, adf_all) = run("all", "all")
+    assert to_numpy(wave_all.array).shape == (2, 1, 5, 5, calc.nz)
+    assert np.all(np.any(np.abs(to_numpy(wave_all.array)) > 0, axis=(0, 1, 2, 3)))
+    assert to_numpy(adf_all.array).shape == (calc.nz, 2, 1)
+
+
+def test_prism_cache_validates_component_rows_not_scan_positions(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def calculator():
+        calc = MultisliceCalculator(force_cpu=True)
+        calc.setup(
+            _make_tiny_trajectory(), aperture=5, voltage_eV=60e3,
+            sampling=1.0, slice_thickness=1.0,
+            probe_xs=[1.0, 2.0], probe_ys=[1.0], prism=2,
+            loop_probes=1, cache_wavefunctions=True)
+        return calc
+
+    first = calculator()
+    expected = to_numpy(first.run(force_rerun=True).array).copy()
+
+    def should_not_propagate(*args, **kwargs):
+        raise AssertionError("valid PRISM component cache was not reused")
+
+    second = calculator()
+    monkeypatch.setattr(calculators_module, "Propagate", should_not_propagate)
+    np.testing.assert_allclose(to_numpy(second.run().array), expected)
+
+
 def test_tacaw_real_space_dispersion_uses_inverse_fft(tmp_path):
     tacaw = TACAWData(_make_wf_data(tmp_path, n_time=4), force_rerun=True)
     reciprocal = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.complex128)
@@ -764,6 +815,99 @@ def test_tacaw_cache_distinguishes_timestep_and_hashes_every_value(tmp_path):
     assert TACAWData._array_fingerprint(large) != fingerprint
 
 
+@pytest.mark.parametrize("chunk_fft", [False, True])
+def test_tacaw_incoherently_folds_decoherence_copies(tmp_path, chunk_fft):
+    backend = NumpyBackend()
+    n_copies, n_scan, nt = 3, 2, 8
+    time = np.arange(nt, dtype=float) * 0.1
+    rows = []
+    for copy in range(n_copies):
+        for scan in range(n_scan):
+            amplitude = 1.0 + copy + scan / 2
+            rows.append(amplitude * np.cos(2 * np.pi * (copy + 1) * time))
+    waves = np.asarray(rows, dtype=np.complex128)[:, :, None, None, None]
+    probe = SimpleNamespace(
+        eV=60e3, wavelength=0.05, mrad=5.0,
+        _array=np.zeros((n_copies, n_scan, 1, 1), dtype=np.complex128))
+    wf = WFData(
+        probe_positions=[(0.0, 0.0), (1.0, 0.0)],
+        probe_xs=[0.0, 1.0], probe_ys=[0.0], time=time,
+        kxs=np.array([0.0]), kys=np.array([0.0]),
+        xs=np.array([0.0]), ys=np.array([0.0]), layer=np.array([0]),
+        array=waves, probe=probe, backend=backend,
+        cache_dir=tmp_path / str(chunk_fft))
+
+    raw = waves[:, :, :, :, 0]
+    raw_fft = np.fft.fftshift(
+        np.fft.fft(raw - raw.mean(axis=1, keepdims=True), axis=1), axes=1)
+    expected = (np.abs(raw_fft) ** 2).reshape(
+        n_copies, n_scan, nt, 1, 1).sum(axis=0)
+
+    tacaw = TACAWData(wf, chunkFFT=chunk_fft, force_rerun=True)
+    assert tacaw.array.shape == (n_scan, nt, 1, 1)
+    np.testing.assert_allclose(tacaw.array, expected)
+    np.testing.assert_allclose(TACAWData(wf, chunkFFT=chunk_fft).array, expected)
+
+    with pytest.raises(ValueError, match="keep_complex"):
+        TACAWData(wf, keep_complex=True, force_rerun=True)
+
+
+def test_calculator_decoherence_flows_into_folded_tacaw(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    positions = np.tile(
+        np.array([[[1.5, 1.5, 1.5]]], dtype=np.float32), (4, 1, 1))
+    trajectory = Trajectory(
+        atom_types=np.array([14]), positions=positions,
+        velocities=np.zeros_like(positions),
+        box_matrix=np.diag([4.0, 4.0, 3.0]), timestep=0.1)
+    calc = MultisliceCalculator(force_cpu=True)
+    calc.setup(
+        trajectory, aperture=20, voltage_eV=60e3, sampling=1.0,
+        slice_thickness=1.0, probe_xs=[1.0, 2.0], probe_ys=[1.0],
+        cache_wavefunctions=False)
+    calc.base_probe.addTemporalDecoherence(2.0, 3)
+    wf = calc.run(force_rerun=True)
+    assert to_numpy(wf.array).shape[:2] == (6, 4)
+
+    raw = to_numpy(wf.array[:, :, :, :, -1])
+    raw_fft = np.fft.fftshift(
+        np.fft.fft(raw - raw.mean(axis=1, keepdims=True), axis=1), axes=1)
+    expected = (np.abs(raw_fft) ** 2).reshape(
+        3, 2, *raw_fft.shape[1:]).sum(axis=0)
+    tacaw = TACAWData(wf, force_rerun=True)
+    assert tacaw.array.shape[0] == 2
+    np.testing.assert_allclose(tacaw.array, expected)
+
+
+@pytest.mark.parametrize("chunk_fft", [False, True])
+def test_tacaw_memmap_writes_a_complete_reusable_cache(tmp_path, chunk_fft):
+    backend = NumpyBackend()
+    nt = 8
+    cache_dir = tmp_path / str(chunk_fft)
+    cache_dir.mkdir()
+    source = backend.memmap(
+        (2, nt, 1, 1, 1), dtype=np.complex128,
+        filename=cache_dir / "wavefunctions.npy")
+    time = np.arange(nt, dtype=float) * 0.1
+    source[0, :, 0, 0, 0] = np.cos(2 * np.pi * time)
+    source[1, :, 0, 0, 0] = 2 * np.cos(4 * np.pi * time)
+    source.flush()
+    probe = SimpleNamespace(
+        eV=60e3, wavelength=0.05, mrad=5.0,
+        _array=np.zeros((2, 1, 1, 1), dtype=np.complex128))
+    wf = WFData(
+        probe_positions=[(0.0, 0.0)], probe_xs=[0.0], probe_ys=[0.0],
+        time=time, kxs=np.array([0.0]), kys=np.array([0.0]),
+        xs=np.array([0.0]), ys=np.array([0.0]), layer=np.array([0]),
+        array=source, probe=probe, backend=backend, cache_dir=cache_dir)
+
+    first = TACAWData(wf, chunkFFT=chunk_fft, force_rerun=True).array.copy()
+    assert (cache_dir / "tacaw.npy").exists()
+    assert (cache_dir / "tacaw_meta.json").exists()
+    second = TACAWData(wf, chunkFFT=chunk_fft).array
+    np.testing.assert_allclose(second, first)
+
+
 def test_cache_versions_are_derived_from_source(tmp_path):
     from pyslice.backend import source_files_version
     # the helper is content-sensitive and tolerates missing files
@@ -959,6 +1103,11 @@ def test_adf_depth_resolved_stack_not_layer_sum(tmp_path, monkeypatch):
     stack = to_numpy(adf_all.array)
     assert stack.ndim == 3 and stack.shape[1:] == (3, 3)
     assert stack.shape[0] == len(adf_all.thicknesses)
+    # Stored waves are captured after each slice transmission, so their depth
+    # is the far boundary of that slice: first > 0 and exit == specimen depth.
+    expected_depths = np.linspace(4.0 / len(stack), 4.0, len(stack))
+    np.testing.assert_allclose(adf_all.thicknesses, expected_depths)
+    np.testing.assert_allclose(adf.thicknesses, [4.0])
     np.testing.assert_allclose(stack[-1], to_numpy(adf.array), atol=1e-6)  # exit == default
     assert not np.allclose(stack[0], stack[-1])          # genuinely per-thickness
     assert not np.allclose(stack[-1], stack.sum(0))      # not the old layer-sum
@@ -1027,7 +1176,8 @@ def test_decoherence_default_wavefunction_storage_keeps_every_copy(tmp_path, mon
     calc.setup(
         traj, aperture=30, voltage_eV=100e3, sampling=0.25,
         slice_thickness=1.0, probe_xs=[2., 4., 6.], probe_ys=[2., 4., 6.],
-        ADF=(45, 150), cache_wavefunctions=True)  # default return_layers=-1
+        ADF=(45, 150), cache_wavefunctions=True,
+        loop_probes=2)  # default return_layers=-1
     calc.base_probe.addTemporalDecoherence(2.0, 3)
     wf, adf = calc.run(force_rerun=True)
     assert wf.array.shape[0] == 3 * 9
@@ -1041,11 +1191,30 @@ def test_decoherence_default_wavefunction_storage_keeps_every_copy(tmp_path, mon
     cached_calc.setup(
         traj, aperture=30, voltage_eV=100e3, sampling=0.25,
         slice_thickness=1.0, probe_xs=[2., 4., 6.], probe_ys=[2., 4., 6.],
-        ADF=(45, 150), cache_wavefunctions=True)
+        ADF=(45, 150), cache_wavefunctions=True, loop_probes=2)
     cached_calc.base_probe.addTemporalDecoherence(2.0, 3)
     cached_wf, cached_adf = cached_calc.run()
     assert cached_wf.array.shape[0] == 3 * 9
     np.testing.assert_allclose(to_numpy(cached_adf.array), expected, rtol=1e-7)
+
+
+def test_cached_looped_adf_uses_full_scan_count(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    traj = _make_tiny_trajectory()
+
+    def calculator():
+        calc = MultisliceCalculator(force_cpu=True)
+        calc.setup(
+            traj, aperture=20, voltage_eV=60e3, sampling=0.5,
+            slice_thickness=1.0, probe_xs=[1.0, 2.0],
+            probe_ys=[1.0, 2.0], loop_probes=2, ADF=(5, 40),
+            cache_wavefunctions=True)
+        return calc
+
+    first = calculator()
+    expected = to_numpy(first.run(force_rerun=True)[1].array).copy()
+    second = calculator()
+    np.testing.assert_allclose(to_numpy(second.run()[1].array), expected)
 
 
 def test_decoherence_weights_preserve_total_probe_dose():

--- a/tests/25_review_regressions.py
+++ b/tests/25_review_regressions.py
@@ -8,7 +8,7 @@ if TORCH_AVAILABLE:
     from pyslice.backend import TorchBackend
 from pyslice.multislice import calculators as calculators_module
 from pyslice.multislice.calculators import MultisliceCalculator
-from pyslice.multislice.multislice import PrismProbe, Probe, wavelength
+from pyslice.multislice.multislice import PrismProbe, Probe, Propagate, wavelength
 from pyslice.multislice.potentials import Potential
 from pyslice.multislice.trajectory import Trajectory
 from pyslice.postprocessing.haadf_data import HAADFData
@@ -477,6 +477,76 @@ def test_malformed_probe_positions_raise_clear_error(tmp_path, monkeypatch):
         with pytest.raises(ValueError, match="probe_positions must be"):
             calc.setup(traj, aperture=5, voltage_eV=60e3, sampling=1.0,
                        slice_thickness=1.0, probe_positions=bad)
+
+
+# ---------------------------------------------------------------------------
+# Regression: probe cropping (min_dk) must (a) not crash on the b.roll call and
+# (b) read the potential sub-window centred on each probe, not the grid corner,
+# for every coherent (decoherence) copy.  For a single-slice potential there is
+# no inter-slice propagation, so a cropped exit wave must EXACTLY equal the
+# uncropped exit wave restricted to that probe's window.
+# ---------------------------------------------------------------------------
+
+def _single_slice_potential(xs, ys):
+    return Potential(
+        xs, ys, np.array([1.5]),
+        positions=np.array([[4.0, 4.0, 1.5]]),  # one atom at cell centre
+        atom_types=np.array([14]),
+        backend=NumpyBackend(),
+        kind="kirkland",
+    )
+
+
+def _propagate(position, cropping, decohere=False):
+    xs = np.linspace(0.0, 8.0, 32, endpoint=False)
+    probe = Probe(xs, xs, mrad=30.0, eV=100e3, backend=NumpyBackend(),
+                  probe_positions=np.asarray([position], dtype=float),
+                  cropping=cropping, defer_shifts=True)
+    if decohere:
+        probe.addTemporalDecoherence(2.0, 3)
+    else:
+        probe.applyShifts()
+    exit_wave = to_numpy(Propagate(probe, _single_slice_potential(xs, xs),
+                                   NumpyBackend(), onthefly=True))
+    return exit_wave, probe
+
+
+def test_cropped_probe_reads_window_centred_on_probe_not_grid_corner():
+    C = 16
+    for position, decohere in [((4.0, 4.0), False),   # centred
+                               ((2.0, 6.0), False),   # off-centre
+                               ((4.0, 4.0), True)]:    # centred + decoherence
+        full, _ = _propagate(position, 0, decohere)
+        crop, probe = _propagate(position, C, decohere)
+        assert crop.shape[-2:] == (C, C)
+        # every coherent copy must match the uncropped window at the probe's
+        # recorded offset (b.roll crash + corner-window + decoherence-row bugs)
+        ox, oy = (int(v) for v in probe.offsets[0])
+        window = full[:, ox:ox + C, oy:oy + C]
+        np.testing.assert_allclose(crop, window, atol=1e-12, rtol=0)
+    # and the centred crop must NOT be the grid-corner window (the old bug)
+    full, _ = _propagate((4.0, 4.0), 0)
+    crop, _ = _propagate((4.0, 4.0), C)
+    assert np.max(np.abs(crop[0] - full[0, 0:C, 0:C])) > 1e-3
+
+
+def test_min_dk_calculator_run_completes(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    static = np.tile(np.array([[[4.0, 4.0, 1.5]]], dtype=float), (2, 1, 1))
+    traj = Trajectory(
+        atom_types=np.array([14]),
+        positions=static,
+        velocities=np.zeros_like(static),
+        box_matrix=np.diag([8.0, 8.0, 3.0]),
+        timestep=0.1,
+    )
+    calc = MultisliceCalculator(force_cpu=True)
+    calc.setup(traj, aperture=30, voltage_eV=100e3, sampling=0.25,
+               slice_thickness=1.0, probe_positions=[(4.0, 4.0), (2.0, 6.0)],
+               min_dk=0.25, cache_wavefunctions=False)
+    arr = to_numpy(calc.run(force_rerun=True).array)  # previously TypeError in b.roll
+    assert np.all(np.isfinite(arr))
+    assert np.max(np.abs(arr)) > 0
 
 
 def _make_wf_data(tmp_path, n_time, backend=None):

--- a/tests/25_review_regressions.py
+++ b/tests/25_review_regressions.py
@@ -747,3 +747,49 @@ def test_cache_versions_are_derived_from_source(tmp_path):
     assert wf_v.startswith("v3-") and len(wf_v) > len("v3-")
     assert tacaw_v.startswith("v1-") and len(tacaw_v) > len("v1-")
     assert wf_v != tacaw_v
+
+
+def test_slice_positions_translates_atoms_into_new_box():
+    # slice_positions shrinks the box to the range width; the kept atoms must be
+    # translated by the range lower bound so they land inside [0, width), not
+    # left at their original coordinates outside the new box.
+    pos = np.array([[[1.0, 1.0, 1.0], [6.0, 6.0, 6.0], [7.5, 2.0, 3.0]]], dtype=float)
+    traj = Trajectory(
+        atom_types=np.array([14, 14, 14]), positions=pos,
+        velocities=np.zeros_like(pos), box_matrix=np.diag([10.0, 10.0, 10.0]),
+        timestep=0.1)
+    sliced = traj.slice_positions(x_range=(5.0, 8.0))
+    assert sliced.n_atoms == 2
+    assert sliced.box_matrix[0, 0] == 3.0
+    xs = sliced.positions[0, :, 0]
+    assert np.all((xs >= 0.0) & (xs <= 3.0))          # atoms 6.0, 7.5 -> 1.0, 2.5
+    np.testing.assert_allclose(sorted(xs), [1.0, 2.5])
+
+
+def test_ovito_cell_matrix_transposed_to_row_convention():
+    from pyslice.io.loader import _ovito_cell_to_row_convention
+    a = np.array([10.0, 0.0, 0.0]); b = np.array([2.0, 10.0, 0.0])
+    c = np.array([1.0, 1.5, 10.0]); origin = np.array([-5.0, 0.0, 0.0])
+    ovito_matrix = np.column_stack([a, b, c, origin])  # vectors in columns, origin last
+    box, got_origin = _ovito_cell_to_row_convention(ovito_matrix)
+    # rows are the lattice vectors (ASE / PySlice convention), not columns
+    np.testing.assert_allclose(box[0], a)
+    np.testing.assert_allclose(box[1], b)
+    np.testing.assert_allclose(box[2], c)
+    np.testing.assert_allclose(got_origin, origin)
+    # a plain orthorhombic zero-origin cell is unchanged by the transpose
+    orth = np.column_stack([np.diag([8.0, 6.0, 4.0]), np.zeros(3)])
+    box2, o2 = _ovito_cell_to_row_convention(orth)
+    np.testing.assert_allclose(box2, np.diag([8.0, 6.0, 4.0]))
+    np.testing.assert_allclose(o2, np.zeros(3))
+
+
+def test_npt_barostat_params_have_physical_units():
+    from ase import units
+    from pyslice.md.molecular_dynamics import MDCalculator
+    externalstress, pfactor = MDCalculator._npt_barostat_params(1.01325, 100.0)
+    # externalstress is ~1 atm in eV/A^3, not 1.01325 eV/A^3 (~162 GPa)
+    np.testing.assert_allclose(externalstress / units.bar, 1.01325, rtol=1e-6)
+    assert externalstress < 1e-6                       # ~6.3e-7, not ~1
+    # pfactor = ptime^2 * B (was 75*fs**2, ~1e5x too small)
+    np.testing.assert_allclose(pfactor, (75 * units.fs) ** 2 * (100.0 * units.GPa))

--- a/tests/25_review_regressions.py
+++ b/tests/25_review_regressions.py
@@ -8,7 +8,7 @@ if TORCH_AVAILABLE:
     from pyslice.backend import TorchBackend
 from pyslice.multislice import calculators as calculators_module
 from pyslice.multislice.calculators import MultisliceCalculator
-from pyslice.multislice.multislice import PrismProbe, wavelength
+from pyslice.multislice.multislice import PrismProbe, Probe, wavelength
 from pyslice.multislice.potentials import Potential
 from pyslice.multislice.trajectory import Trajectory
 from pyslice.postprocessing.haadf_data import HAADFData
@@ -306,6 +306,97 @@ def _make_tiny_trajectory():
         box_matrix=np.diag([4.0, 4.0, 3.0]),
         timestep=0.1,
     )
+
+
+# ---------------------------------------------------------------------------
+# Regression: single off-centre probe must not be re-shifted every frame.
+#
+# Probe.applyShifts positions the probe with a k-space phase ramp.  It used to
+# guard against re-application only via "npt > 1", which never triggers for a
+# single probe position, so setup()'s shift plus run()'s per-frame shift (plus
+# the trailing shift inside addTemporalDecoherence) compounded and the probe
+# drifted across frames.  For TACAW this dwarfs the phonon signal.
+# ---------------------------------------------------------------------------
+
+# Grid + aperture chosen so the probe is well localised (aperture spans many
+# k-pixels); on a coarse grid the probe degenerates to a plane wave whose |ψ|²
+# is shift-invariant, which would hide the drift entirely.
+_UNIT_XS = np.linspace(0.0, 8.0, 32, endpoint=False)  # dx = 0.25, centre = 4.0
+_UNIT_YS = np.linspace(0.0, 8.0, 32, endpoint=False)
+_OFFCENTRE = (2.0, 2.0)          # peak pixel 2.0/0.25 = 8 when shifted once
+_ONCE_PIXEL = (8, 8)             # (unshifted -> 16, double-shifted -> 0)
+
+
+def _peak_pixel(array2d):
+    intensity = np.abs(to_numpy(array2d)) ** 2
+    return np.unravel_index(int(np.argmax(intensity)), intensity.shape)
+
+
+def _make_deferred_probe(position):
+    return Probe(
+        _UNIT_XS, _UNIT_YS, mrad=30.0, eV=60e3, backend=NumpyBackend(),
+        probe_positions=np.asarray([position], dtype=float),
+        defer_shifts=True,
+    )
+
+
+def test_apply_shifts_is_idempotent_for_single_offcentre_probe():
+    probe = _make_deferred_probe(_OFFCENTRE)  # cell centre is 4.0 -> off-centre
+
+    probe.applyShifts()
+    after_first = to_numpy(probe._array).copy()
+    probe.applyShifts()  # the historically buggy re-application
+    probe.applyShifts()
+
+    np.testing.assert_array_equal(to_numpy(probe._array), after_first)
+    # positioned once: peak at the requested position (not centre, not doubled)
+    assert _peak_pixel(probe._array[0, 0]) == _ONCE_PIXEL
+
+
+def test_apply_shifts_reapplied_after_decoherence_rebuild():
+    # setup() applies shifts; addTemporalDecoherence then rebuilds the template
+    # from scratch and must re-position it (flag reset), then stay idempotent.
+    probe = _make_deferred_probe(_OFFCENTRE)
+    probe.applyShifts()
+    probe.addTemporalDecoherence(sigma_eV=1.0, N=3)
+
+    assert probe._array.shape[0] == 3  # three energy copies
+    summed = np.sum(np.abs(to_numpy(probe._array[:, 0])) ** 2, axis=0)
+    assert _peak_pixel(summed) == _ONCE_PIXEL  # shifted exactly once, not twice
+
+    frozen = to_numpy(probe._array).copy()
+    probe.applyShifts()  # must be a no-op now
+    np.testing.assert_array_equal(to_numpy(probe._array), frozen)
+
+
+def test_static_trajectory_offcentre_probe_gives_frame_invariant_exit_wave(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    n_frames = 4
+    static = np.tile(np.array([[[3.1, 4.7, 1.5]]], dtype=float), (n_frames, 1, 1))
+    traj = Trajectory(
+        atom_types=np.array([14]),
+        positions=static,
+        velocities=np.zeros_like(static),
+        box_matrix=np.diag([8.0, 8.0, 3.0]),
+        timestep=0.1,
+    )
+    calc = MultisliceCalculator(force_cpu=True)
+    calc.setup(
+        traj,
+        aperture=30,
+        voltage_eV=60e3,
+        sampling=0.25,
+        slice_thickness=1.0,
+        probe_positions=[_OFFCENTRE],
+        cache_wavefunctions=False,
+    )
+    arr = to_numpy(calc.run(force_rerun=True).array)  # (probe, frame, kx, ky, layer)
+
+    # atoms are frozen -> a correctly-fixed probe reproduces the exit wave every
+    # frame; the drift bug moved the probe each frame, so patterns diverged.
+    reference = arr[:, 0]
+    for t in range(1, n_frames):
+        np.testing.assert_allclose(arr[:, t], reference, atol=1e-10, rtol=0)
 
 
 def _make_wf_data(tmp_path, n_time, backend=None):

--- a/tests/25_review_regressions.py
+++ b/tests/25_review_regressions.py
@@ -812,3 +812,44 @@ def test_counts_samples_from_intensity_not_amplitude():
     hits = to_numpy(wf._array).ravel()
     ratio = hits[1] / hits[0]
     assert 8.3 < ratio < 9.7, ratio          # intensity 9:1, not amplitude 3:1
+
+
+def test_loader_parse_index_forms():
+    from pyslice.io.loader import _parse_index
+    assert _parse_index(":") == slice(None, None, None)
+    assert _parse_index(":3") == slice(None, 3, None)
+    assert _parse_index("-3:") == slice(-3, None, None)
+    assert _parse_index("::2") == slice(None, None, 2)
+    assert _parse_index("3:5") == slice(3, 5, None)
+    assert _parse_index("3-5") == slice(3, 6, None)   # inclusive dash range
+    assert _parse_index("1") == 1
+    assert _parse_index(-1) == -1
+    import pytest as _pytest
+    with _pytest.raises(ValueError):
+        _parse_index("nonsense")
+
+
+def test_multiframe_cif_loads_all_frames_and_index_selects(tmp_path):
+    ase_io = pytest.importorskip("ase.io")
+    from ase import Atoms
+    frames = [Atoms("H", positions=[[float(i), 0.0, 0.0]], cell=[10, 10, 10], pbc=True)
+              for i in range(6)]
+    cif = tmp_path / "traj.cif"
+    ase_io.write(str(cif), frames)
+    from pyslice.io.loader import Loader
+
+    def load(index):
+        return Loader(str(cif), timestep=0.5, index=index).load()
+
+    # default reads every image (previously only the last one survived)
+    full = load(":")
+    assert full.n_frames == 6
+    np.testing.assert_allclose(full.positions[:, 0, 0], np.arange(6))
+    # selectors
+    assert load(":3").n_frames == 3
+    np.testing.assert_allclose(load("-3:").positions[:, 0, 0], [3, 4, 5])
+    np.testing.assert_allclose(load("3-5").positions[:, 0, 0], [3, 4, 5])  # inclusive
+    strided = load("::2")
+    np.testing.assert_allclose(strided.positions[:, 0, 0], [0, 2, 4])
+    assert strided.timestep == 1.0                    # step rescales timestep
+    assert load(1).n_frames == 1

--- a/tests/25_review_regressions.py
+++ b/tests/25_review_regressions.py
@@ -581,6 +581,21 @@ def test_pad_real_space_preserves_field_for_odd_and_even_grids(tmp_path, n):
     assert rel_err < 1e-10
 
 
+def test_slice_axis_other_than_z_is_rejected(tmp_path, monkeypatch):
+    # slice_axis != 2 was silently wrong (propagation is z-locked); it must now
+    # fail loudly at both entry points.
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(NotImplementedError, match="slice_axis"):
+        MultisliceCalculator(force_cpu=True).setup(
+            _make_tiny_trajectory(), aperture=5, voltage_eV=60e3, sampling=1.0,
+            slice_thickness=1.0, slice_axis=1)
+    with pytest.raises(NotImplementedError, match="slice_axis"):
+        Potential(np.arange(3.0), np.arange(3.0), np.arange(3.0),
+                  positions=np.array([[1.0, 1.0, 1.0]]),
+                  atom_types=np.array([14]), backend=NumpyBackend(),
+                  kind="gauss", slice_axis=0)
+
+
 def test_pyproject_sdist_ships_package_source():
     # The sdist must declare the package source; otherwise hatchling shipped a
     # data-only sdist and every sdist-based install produced an empty package.

--- a/tests/25_review_regressions.py
+++ b/tests/25_review_regressions.py
@@ -633,6 +633,132 @@ def test_pad_real_space_preserves_field_for_odd_and_even_grids(tmp_path, n):
     assert rel_err < 1e-10
 
 
+def _make_optics_wf(tmp_path, n=5):
+    xs = np.arange(n, dtype=float)
+    kxs = np.fft.fftshift(np.fft.fftfreq(n))
+    x_grid, y_grid = np.meshgrid(xs, xs, indexing="ij")
+    entrance = (1 + x_grid + 2 * y_grid).astype(np.complex128)
+    exit_wave = np.exp(-((x_grid - 1.3) ** 2 + (y_grid - 3.1) ** 2) / 2)
+    waves = np.stack(
+        [np.fft.fftshift(np.fft.fft2(entrance)),
+         np.fft.fftshift(np.fft.fft2(exit_wave))],
+        axis=-1,
+    )[None, None, :, :, :]
+    probe = SimpleNamespace(
+        eV=1e5, wavelength=0.037, mrad=30.0,
+        _array=NumpyBackend().asarray(
+            np.zeros((1, 1, n, n), dtype=np.complex128)))
+    return WFData(
+        probe_positions=[(2.0, 2.0)], probe_xs=[2.0], probe_ys=[2.0],
+        time=np.zeros(1), kxs=kxs, kys=kxs.copy(),
+        xs=xs, ys=xs.copy(), layer=np.array([1.0, 2.0]),
+        array=waves, probe=probe, backend=NumpyBackend(), cache_dir=tmp_path,
+    )
+
+
+def test_free_space_propagates_only_the_exit_wave(tmp_path):
+    wf = _make_optics_wf(tmp_path)
+    before = to_numpy(wf.array).copy()
+    dz = 80.0
+
+    wf.propagate_free_space(dz)
+
+    after = to_numpy(wf.array)
+    np.testing.assert_array_equal(after[..., 0], before[..., 0])
+    kx_grid, ky_grid = np.meshgrid(wf.kxs, wf.kys, indexing="ij")
+    propagator = np.exp(
+        -1j * np.pi * wf.probe.wavelength * dz
+        * (kx_grid ** 2 + ky_grid ** 2)
+    )
+    np.testing.assert_allclose(
+        after[..., -1], before[..., -1] * propagator[None, None, :, :]
+    )
+
+
+def test_lens_is_grid_centred_and_modifies_only_the_exit_wave(tmp_path):
+    wf = _make_optics_wf(tmp_path)
+    before = to_numpy(wf.array).copy()
+    f = 500.0
+
+    wf.propagate_through_lens(f)
+
+    after = to_numpy(wf.array)
+    np.testing.assert_array_equal(after[..., 0], before[..., 0])
+    real_before = np.fft.ifft2(np.fft.ifftshift(before[0, 0, :, :, -1]))
+    real_after = np.fft.ifft2(np.fft.ifftshift(after[0, 0, :, :, -1]))
+    x_grid, y_grid = np.meshgrid(
+        wf.xs - np.mean(wf.xs), wf.ys - np.mean(wf.ys), indexing="ij"
+    )
+    expected_lens = np.exp(
+        -1j * (2 * np.pi / wf.probe.wavelength) / (2 * f)
+        * (x_grid ** 2 + y_grid ** 2)
+    )
+    np.testing.assert_allclose(real_after, real_before * expected_lens, atol=1e-12)
+
+
+def test_lens_accepts_an_explicit_optical_axis(tmp_path):
+    wf = _make_optics_wf(tmp_path)
+    before = to_numpy(wf.array).copy()
+    f = 500.0
+    center = (1.0, 3.0)
+
+    wf.propagate_through_lens(f, center=center)
+
+    real_before = np.fft.ifft2(np.fft.ifftshift(before[0, 0, :, :, -1]))
+    real_after = np.fft.ifft2(
+        np.fft.ifftshift(to_numpy(wf.array)[0, 0, :, :, -1])
+    )
+    x_grid, y_grid = np.meshgrid(
+        wf.xs - center[0], wf.ys - center[1], indexing="ij"
+    )
+    expected_lens = np.exp(
+        -1j * (2 * np.pi / wf.probe.wavelength) / (2 * f)
+        * (x_grid ** 2 + y_grid ** 2)
+    )
+    np.testing.assert_allclose(real_after, real_before * expected_lens, atol=1e-12)
+
+
+def test_downstream_optics_use_each_decoherence_copy_wavelength(tmp_path):
+    n = 5
+    n_copies, n_positions = 2, 2
+    xs = np.arange(n, dtype=float)
+    kxs = np.fft.fftshift(np.fft.fftfreq(n))
+    wavelengths = np.array([0.03, 0.06])
+    probe = SimpleNamespace(
+        eV=1e5, wavelength=wavelengths[0], wavelengths=wavelengths,
+        mrad=30.0,
+        _array=np.zeros((n_copies, n_positions, n, n), dtype=np.complex128),
+    )
+    # Flattening is copy-major: each wavelength applies to all scan positions
+    # for one decoherence copy.
+    array = np.ones(
+        (n_copies * n_positions, 1, n, n, 2), dtype=np.complex128
+    )
+    wf = WFData(
+        probe_positions=[(1.0, 1.0), (3.0, 3.0)],
+        probe_xs=[1.0, 3.0], probe_ys=[1.0, 3.0], time=np.zeros(1),
+        kxs=kxs, kys=kxs.copy(), xs=xs, ys=xs.copy(),
+        layer=np.array([1.0, 2.0]), array=array, probe=probe,
+        backend=NumpyBackend(), cache_dir=tmp_path,
+    )
+    before = wf.array.copy()
+    dz = 80.0
+
+    wf.propagate_free_space(dz)
+
+    kx_grid, ky_grid = np.meshgrid(kxs, kxs, indexing="ij")
+    k_sq = kx_grid ** 2 + ky_grid ** 2
+    for copy, wavelength_value in enumerate(wavelengths):
+        expected = np.exp(-1j * np.pi * wavelength_value * dz * k_sq)
+        start = copy * n_positions
+        stop = start + n_positions
+        np.testing.assert_allclose(
+            wf.array[start:stop, 0, :, :, -1],
+            np.broadcast_to(expected, (n_positions, n, n)),
+        )
+    np.testing.assert_array_equal(wf.array[..., 0], before[..., 0])
+
+
 def test_slice_axis_other_than_z_is_rejected(tmp_path, monkeypatch):
     # slice_axis != 2 was silently wrong (propagation is z-locked); it must now
     # fail loudly at both entry points.

--- a/tests/26_lenses.py
+++ b/tests/26_lenses.py
@@ -31,7 +31,6 @@ calculator.setup(trajectory,aperture=5,voltage_eV=100e3)
 
 exitwaves = calculator.run()
 
-exitwaves.recenter()
 exitwaves.plot_realspace(filename="outputs/figs/26_lenses_0_orig.png")
 exitwaves.pad_real_space(100,100)
 exitwaves.plot_realspace(filename="outputs/figs/26_lenses_1_pad.png")
@@ -44,4 +43,3 @@ exitwaves.propagate_through_lens(1000)
 for n in range(30):
     exitwaves.propagate_free_space(50)
     exitwaves.plot_realspace(filename="outputs/figs/26_lenses_"+str(n+3)+"_"+str(100+5*(n+1))+"nm.png")
-


### PR DESCRIPTION
Hi @h-walk and @tpchuckles !

I have had Claude Code do a review of the current main branch of the PySlice package and it found a bunch of things, which are fixed in this PR. I have guided the AI through the revision process and double checked that the issues are actual issues. Please find the details below.

## Overview

This PR collects a set of independent fixes found during a review of the
PySlice package. Most address **silently wrong results** (no crash, plausible
output) in specific configurations; a few fix outright crashes or a broken
install. Two changes are additive features (CIF frame selection, depth-resolved
ADF). Each commit is self-contained and ships with a focused regression test
that fails on the pre-fix code and passes after; the full test suite is green.

Default/common-path behaviour is preserved throughout — the shape-changing
change (ADF) collapses to the previous 2D result for the single-thickness
default, and every new parameter defaults to the old behaviour.

## Changes

### Probe positioning
- **Single off-centre probe re-shifted every frame** (`0faa786`). `applyShifts`
  was idempotent only for `npt > 1`, so `setup()` plus `run()`'s per-frame call
  displaced a single off-centre probe further each frame, dominating the
  frame-to-frame signal a TACAW run measures. Tracked with an explicit
  "shifts applied" flag, reset on template rebuild and inherited by `copy()`.
- **Explicit `probe_positions` list crash / mis-mapping** (`f1e0d79`). An
  explicit list was silently rebuilt into the outer-product grid of its unique
  x/y values, changing the simulated positions and desyncing `n_probes` from
  the number of probes (shape-mismatch crash when returning wavefunctions).
  Positions are now simulated exactly; a full grid supplied in any order is
  canonicalised so the 2D image still maps correctly; malformed input raises a
  clear error.
- **Probe cropping (`min_dk`) crash and wrong window** (`f0a92b2`). `b.roll`
  was called without its required `axis` argument (every cropping run crashed);
  fixing that exposed two masked bugs — decoherence copies read the grid corner,
  and a centred cropped probe read the corner instead of its window. All three
  fixed; verified a cropped exit wave equals the uncropped window to machine
  precision.

### FFT / postprocessing
- **`pad_real_space` odd-grid corruption** (`1393358`). The FFT round trip
  omitted the `ifftshift`/`fftshift` pair, exact only for even grid sizes; odd
  grids (routine, since `nx = int(lx/sampling)+1`) were smeared by several
  percent. Wrapped to match the existing `applyMask` convention.
- **`counts()` sampled amplitude, not intensity** (`3ef8052`). The shot-noise
  CDF was built from `|psi|` instead of `|psi|^2`, over-counting weak features
  (a pixel 100x weaker in intensity was only 10x less likely to be hit).

### Multislice geometry
- **`slice_axis != 2` produced silently wrong geometry** (`897457b`).
  Propagation is hard-coded to the z axis while `Potential` slices along
  `slice_axis`; a non-z value laid the wrong coordinate onto the grid and used
  the wrong spacing. Now rejected with a clear `NotImplementedError` (no user or
  test relies on it); permute the trajectory so the beam axis is z.

### IO / loader
- **OVITO type IDs treated as atomic numbers** (`61c3b70`). Without an
  `atom_mapping`, LAMMPS type IDs (1, 2, ...) were used verbatim as Z, so a Si/O
  dump was simulated as H/He (~10x wrong scattering). Element identity now comes
  from an explicit mapping or the file's embedded element names; if neither is
  available, loading aborts asking for an exact mapping. Type IDs are never used
  as Z.
- **OVITO cell matrix transpose + origin** (`bb54f67`). OVITO stores lattice
  vectors in the columns of a 3x4 matrix (4th column = origin); the loader kept
  the 3x3 block verbatim, giving a transposed box for triclinic cells, and
  discarded the origin. Now transposed to the row convention used everywhere
  else, with positions referenced to the origin. No-op for orthorhombic
  zero-origin cells.
- **`slice_positions` did not translate atoms** (`bb54f67`). It shrank the box
  to the range width but left kept atoms at their original coordinates, outside
  the new box. Now translated by the range lower bound.
- **Multi-frame CIF dropped all but the last image** (`d08afb5`).
  `ase.io.read` was called without an index, inheriting ASE's `index=-1`
  default. Now reads every image, and adds an ASE-like `index` parameter to
  `Loader` (`":"`, `":3"`, `"-3:"`, `"::2"`, `"3:5"`, `"3-5"`, or an int) for
  choosing frames; default `":"` loads all. Applied after loading so the cache
  stores the full trajectory; a step rescales the timestep (as `slice_timesteps`
  does).

### Molecular dynamics
- **NPT unit bugs** (`bb54f67`). `externalstress` was passed as the raw bar
  value into an eV/A^3 argument (~162 GPa instead of 1 atm), and `pfactor` was
  `75*units.fs**2` — missing the square on ptime and the bulk modulus (barostat
  mass ~1e5x too small). Centralised in `_npt_barostat_params` (with a new
  `bulk_modulus` setup parameter, GPa) as `externalstress = pressure*units.bar`,
  `pfactor = (75 fs)^2 * B`.

### Caching
- **Cache identities were too narrow** (`b284010`). The wavefunction cache
  fingerprinted only frame 0's first 100 x-coordinates, so runs differing in
  later frames or in y/z (e.g. a temperature sweep from the same initial
  structure) collided and reused each other's exit waves; it also omitted
  several physics parameters. The TACAW cache validated only array shape, so a
  different layer / dtype / dataset in the same cache dir was served the wrong
  spectrum. Both now key on the full identity (full trajectory hash + all
  parameters; a metadata sidecar with a completion marker for TACAW), while
  identical inputs still share a cache.
- **Cache versions derived from source** (`30e6523`). The cache-version tags now
  hash the source modules whose logic determines the cached values, so a change
  to the physics/FFT code invalidates stale caches automatically instead of
  needing a manual bump. Errs toward over-invalidation (recompute is the safe
  failure mode); a manual prefix still allows a forced bump.

### ADF / HAADF
- **Depth-resolved ADF; layer-sum and decoherence bugs** (`6265110`). The ADF
  summed intensity across all stored layers into one image (wrong for
  multi-layer runs) and dropped all but the first decoherence copy. The ADF is
  now **one image per stored thickness**: `(n_layers, gx, gy)`, chosen via
  `return_layers`, with `.thicknesses` (z of each slice) on the result and a
  `layer` argument on `HAADFData.plot()`. It collapses to a plain 2D image for
  the single-thickness default (unchanged API). Decoherence copies are summed
  (incoherent sum) rather than dropped.

### Packaging
- **Empty sdist** (`457dc05`). A global data-only `include` starved the sdist
  (and thus `python -m build`'s wheel) of all Python source, so sdist-based
  installs produced an empty package. Gave the sdist target a source file list
  and removed a dead setuptools placeholder. Verified `python -m build` now
  ships the modules and data, and the installed wheel imports and loads the
  Kirkland parameters.

## Testing

Regression tests were added alongside each fix (in `tests/25_review_regressions.py`
and the ADF/loader paths), each verified to fail on the pre-fix code and pass
after. Numerical fixes were checked against independent references (e.g. cropped
vs uncropped propagation, `pad_real_space` recovery, NPT units, decoherence
sum). The full suite passes.

## Backward compatibility

- ADF: single-thickness result stays a 2D `(gx, gy)` image; the stack only
  appears when multiple layers are requested.
- Loader `index` defaults to `":"` (all frames) and is applied as a post-load
  view, so the on-disk cache format is unchanged and existing loads behave
  identically.
- Cache keys changed by design (they now include more state); old cache
  directories are simply not reused — no corruption, just recomputation.